### PR TITLE
add edge searching and result filtering

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -132,16 +132,11 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, valhalla:
   PathLocation correlated(location);
   if(closest_edge != nullptr){
     //compute partial distance along the shape
-    float partial_length = 0, total_length = 0;
-    for(size_t i = 1; i < closest_edge_info->shape().size(); ++i) {
-      //still doing partial distance
-      if(i < std::get<2>(closest_point))
-        partial_length = total_length = partial_length + closest_edge_info->shape()[i - 1].Distance(closest_edge_info->shape()[i]);
-      else
-        total_length = total_length + closest_edge_info->shape()[i - 1].Distance(closest_edge_info->shape()[i]);
-    }
+    float partial_length = 0;
+    for(size_t i = 1; i < std::get<2>(closest_point); ++i)
+        partial_length += closest_edge_info->shape()[i - 1].Distance(closest_edge_info->shape()[i]);
     partial_length += closest_edge_info->shape()[std::get<2>(closest_point)].Distance(std::get<0>(closest_point));
-    float length_ratio = partial_length / total_length;
+    float length_ratio = partial_length / closest_edge->length();
     //correlate it
     correlated.CorrelateEdge(closest_edge_id, length_ratio);
     //we need the opposing edge as well

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -131,15 +131,17 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, valhalla:
   //now that we have a node we can pass back all the edges leaving it
   PathLocation correlated(location);
   if(closest_edge != nullptr){
+    //correlate the spot
+    correlated.CorrelateVertex(std::get<0>(closest_point));
     //compute partial distance along the shape
     float partial_length = 0;
     for(size_t i = 1; i < std::get<2>(closest_point); ++i)
         partial_length += closest_edge_info->shape()[i - 1].Distance(closest_edge_info->shape()[i]);
     partial_length += closest_edge_info->shape()[std::get<2>(closest_point)].Distance(std::get<0>(closest_point));
     float length_ratio = partial_length / closest_edge->length();
-    //correlate it
+    //correlate the edge we found
     correlated.CorrelateEdge(closest_edge_id, length_ratio);
-    //we need the opposing edge as well
+    //correlate its evil twin
     const auto other_tile = reader.GetGraphTile(closest_edge->endnode());
     const auto end_node = other_tile->node(closest_edge->endnode());
     auto opposing_edge_id = closest_edge->endnode();

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -77,7 +77,6 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, valhalla:
   //TODO: be smarter about this either in loki or in baldr cache
   if(!tile)
     throw std::runtime_error("No data found for location");
-  throw std::runtime_error("Unimplemented");
 
   //a place to keep the closest information so far
   const DirectedEdge* closest_edge = nullptr;
@@ -94,10 +93,10 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, valhalla:
     const DirectedEdge* edge = tile->directededge(static_cast<size_t>(edge_index));
 
     //we haven't looked at this edge yet
-    auto inserted = searched.insert(edge->edgedataoffset());
+    auto inserted = searched.insert(edge->edgeinfo_offset());
     if(inserted.second) {
       //get some info about the edge
-      auto edge_info = tile->edgeinfo(edge->edgedataoffset());
+      auto edge_info = tile->edgeinfo(edge->edgeinfo_offset());
       auto candidate = location.latlng_.ClosestPoint(edge_info->shape());
 
       //is this really close to the geometry

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -1,13 +1,14 @@
 #include "loki/search.h"
 
 #include <unordered_set>
-#include <valhalla/midgard/logging.h>
 
 using namespace valhalla::baldr;
 
 namespace {
 
-constexpr float NODE_SNAP = 8 * 8; //we are working in square meters below
+//during edge searching we snap to vertices if you are closer than
+//10 meters to a given vertex.
+constexpr float NODE_SNAP = 15 * 15;
 
 const DirectedEdge* GetOpposingEdge(GraphReader& reader, const DirectedEdge* edge) {
   //get the node at the end of this edge
@@ -126,7 +127,6 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, valhalla:
 
       //does this look better than the current edge
       if(std::get<1>(candidate) < std::get<1>(closest_point)) {
-        LOG_INFO("Found " + tile->GetNames(edge->edgeinfo_offset())[0] + " using offset " + std::to_string(edge->edgeinfo_offset()));
         closest_edge = edge;
         closest_edge_id.fields.id = edge_index;
         closest_edge_info.swap(edge_info);

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -1,8 +1,23 @@
 #include "loki/search.h"
 
+#include <unordered_set>
+
 using namespace valhalla::baldr;
 
 namespace {
+
+constexpr float NODE_SNAP = 8 * 8; //we are working in square meters below
+
+const DirectedEdge* GetOpposingEdge(GraphReader& reader, const DirectedEdge* edge) {
+  //get the node at the end of this edge
+  const auto node_id = edge->endnode();
+  //we are looking for the nth edge exiting this node
+  const auto opposing_index = edge->opp_index();
+  //the node could be in another tile so we grab that
+  const auto tile = reader.GetGraphTile(node_id);
+  //grab the nth edge leaving the node
+  return tile->directededge(tile->node(node_id)->edge_index() + opposing_index);
+}
 
 PathLocation CorrelateNode(const NodeInfo* closest, const Location& location, const GraphTile* tile, valhalla::loki::EdgeFilter filter){
   //now that we have a node we can pass back all the edges leaving it
@@ -55,7 +70,96 @@ PathLocation NodeSearch(const Location& location, GraphReader& reader, valhalla:
 }
 
 PathLocation EdgeSearch(const Location& location, GraphReader& reader, valhalla::loki::EdgeFilter filter) {
-  throw std::runtime_error("Edge searching is unimplemented");
+  //grab the tile the lat, lon is in
+  const GraphTile* tile = reader.GetGraphTile(location.latlng_);
+
+  //we couldn't find any data for this region
+  //TODO: be smarter about this either in loki or in baldr cache
+  if(!tile)
+    throw std::runtime_error("No data found for location");
+  throw std::runtime_error("Unimplemented");
+
+  //a place to keep the closest information so far
+  const DirectedEdge* closest_edge = nullptr;
+  GraphId closest_edge_id;
+  std::unique_ptr<const EdgeInfo> closest_edge_info;
+  std::tuple<valhalla::midgard::PointLL, float, int> closest_point{{}, std::numeric_limits<float>::max(), 0};
+
+  //a place to keep track of the edgeinfos we've already inspected
+  std::unordered_set<uint32_t> searched(tile->header()->directededgecount());
+
+  //for each edge
+  for(uint32_t edge_index = 0; edge_index < tile->header()->directededgecount(); ++edge_index) {
+    //get the edge
+    const DirectedEdge* edge = tile->directededge(static_cast<size_t>(edge_index));
+
+    //we haven't looked at this edge yet
+    auto inserted = searched.insert(edge->edgedataoffset());
+    if(inserted.second) {
+      //get some info about the edge
+      auto edge_info = tile->edgeinfo(edge->edgedataoffset());
+      auto candidate = location.latlng_.ClosestPoint(edge_info->shape());
+
+      //is this really close to the geometry
+      if(std::get<1>(candidate) < NODE_SNAP)
+      {
+        //is it basically right on the start of the line
+        if(std::get<2>(candidate) == 0) {
+          //get the opposing edge of this one
+          const auto opposing_edge = GetOpposingEdge(reader, edge);
+          return CorrelateNode(tile->node(opposing_edge->endnode()), location, tile, filter);
+        }//is it basically right on the end of the line
+        else if(std::get<2>(candidate) == edge_info->shape().size() - 2) {
+          //the end node could be in another tile
+          auto node_id = edge->endnode();
+          tile = reader.GetGraphTile(node_id);
+          return CorrelateNode(tile->node(node_id), location, tile, filter);
+        }
+      }
+
+      //does this look better than the current edge
+      if(std::get<1>(candidate) < std::get<1>(closest_point)) {
+        closest_edge = edge;
+        //TODO: this is totally lame..waiting for the header to have a graphid to use
+        closest_edge_id = GetOpposingEdge(reader, edge)->endnode();
+        closest_edge_id.Set(closest_edge_id.tileid(), closest_edge_id.level(), edge_index);
+        closest_edge_info.swap(edge_info);
+        std::swap(closest_point, candidate);
+      }
+    }
+  }
+
+  //now that we have a node we can pass back all the edges leaving it
+  PathLocation correlated(location);
+  if(closest_edge != nullptr){
+    //compute partial distance along the shape
+    float partial_length = 0, total_length = 0;
+    for(size_t i = 1; i < closest_edge_info->shape().size(); ++i) {
+      //still doing partial distance
+      if(i < std::get<2>(closest_point))
+        partial_length = total_length = partial_length + closest_edge_info->shape()[i - 1].Distance(closest_edge_info->shape()[i]);
+      else
+        total_length = total_length + closest_edge_info->shape()[i - 1].Distance(closest_edge_info->shape()[i]);
+    }
+    partial_length += closest_edge_info->shape()[std::get<2>(closest_point)].Distance(std::get<0>(closest_point));
+    float length_ratio = partial_length / total_length;
+    //correlate it
+    correlated.CorrelateEdge(closest_edge_id, length_ratio);
+    //we need the opposing edge as well
+    const auto other_tile = reader.GetGraphTile(closest_edge->endnode());
+    const auto end_node = other_tile->node(closest_edge->endnode());
+    auto opposing_edge_id = closest_edge->endnode();
+    //TODO: this is totally lame..waiting for the header to have a graphid to use
+    opposing_edge_id.Set(opposing_edge_id.tileid(), opposing_edge_id.level(), end_node->edge_index() + closest_edge->opp_index());
+    correlated.CorrelateEdge(opposing_edge_id, 1 - length_ratio);
+  }
+
+  //if we found nothing that is no good..
+  if(correlated.edges().size() == 0)
+    throw std::runtime_error("Unable to find any edges connected to this location");
+
+  //give it back
+  return correlated;
 }
 
 }

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -80,9 +80,9 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, valhalla:
 
   //a place to keep the closest information so far
   const DirectedEdge* closest_edge = nullptr;
-  GraphId closest_edge_id;
+  GraphId closest_edge_id = tile->header()->graphid();
   std::unique_ptr<const EdgeInfo> closest_edge_info;
-  std::tuple<valhalla::midgard::PointLL, float, int> closest_point{{}, std::numeric_limits<float>::max(), 0};
+  std::tuple<valhalla::midgard::PointLL, double, int> closest_point{{}, std::numeric_limits<double>::max(), 0};
 
   //a place to keep track of the edgeinfos we've already inspected
   std::unordered_set<uint32_t> searched(tile->header()->directededgecount());
@@ -103,12 +103,16 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, valhalla:
       if(std::get<1>(candidate) < NODE_SNAP)
       {
         //is it basically right on the start of the line
-        if(std::get<2>(candidate) == 0) {
+        if(std::get<2>(candidate) == 0 &&
+          std::get<0>(candidate).DistanceSquared(edge_info->shape().front()) < NODE_SNAP) {
+
           //get the opposing edge of this one
           const auto opposing_edge = GetOpposingEdge(reader, edge);
           return CorrelateNode(tile->node(opposing_edge->endnode()), location, tile, filter);
         }//is it basically right on the end of the line
-        else if(std::get<2>(candidate) == edge_info->shape().size() - 2) {
+        else if(std::get<2>(candidate) == edge_info->shape().size() - 2 &&
+          std::get<0>(candidate).DistanceSquared(edge_info->shape().back()) < NODE_SNAP) {
+
           //the end node could be in another tile
           auto node_id = edge->endnode();
           tile = reader.GetGraphTile(node_id);
@@ -119,9 +123,7 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, valhalla:
       //does this look better than the current edge
       if(std::get<1>(candidate) < std::get<1>(closest_point)) {
         closest_edge = edge;
-        //TODO: this is totally lame..waiting for the header to have a graphid to use
-        closest_edge_id = GetOpposingEdge(reader, edge)->endnode();
-        closest_edge_id.Set(closest_edge_id.tileid(), closest_edge_id.level(), edge_index);
+        closest_edge_id.fields.id = edge_index;
         closest_edge_info.swap(edge_info);
         std::swap(closest_point, candidate);
       }
@@ -134,19 +136,18 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, valhalla:
     //correlate the spot
     correlated.CorrelateVertex(std::get<0>(closest_point));
     //compute partial distance along the shape
-    float partial_length = 0;
+    double partial_length = 0;
     for(size_t i = 1; i < std::get<2>(closest_point); ++i)
         partial_length += closest_edge_info->shape()[i - 1].Distance(closest_edge_info->shape()[i]);
     partial_length += closest_edge_info->shape()[std::get<2>(closest_point)].Distance(std::get<0>(closest_point));
-    float length_ratio = partial_length / closest_edge->length();
+    float length_ratio = static_cast<float>(partial_length / static_cast<double>(closest_edge->length()));
     //correlate the edge we found
     correlated.CorrelateEdge(closest_edge_id, length_ratio);
     //correlate its evil twin
     const auto other_tile = reader.GetGraphTile(closest_edge->endnode());
     const auto end_node = other_tile->node(closest_edge->endnode());
-    auto opposing_edge_id = closest_edge->endnode();
-    //TODO: this is totally lame..waiting for the header to have a graphid to use
-    opposing_edge_id.Set(opposing_edge_id.tileid(), opposing_edge_id.level(), end_node->edge_index() + closest_edge->opp_index());
+    auto opposing_edge_id = other_tile->header()->graphid();
+    opposing_edge_id.fields.id = end_node->edge_index() + closest_edge->opp_index();
     correlated.CorrelateEdge(opposing_edge_id, 1 - length_ratio);
   }
 

--- a/test/search.cc
+++ b/test/search.cc
@@ -134,16 +134,16 @@ void edge_search(valhalla::baldr::GraphReader& reader, const valhalla::baldr::Lo
   const std::string& expected_name, const float expected_distance){
   valhalla::baldr::PathLocation p = valhalla::loki::Search(location, reader, valhalla::loki::SearchStrategy::EDGE);
   if(!p.IsCorrelated())
-      throw std::runtime_error("Didn't find any node/edges");
-    if(p.IsNode() != (expected_distance == 0.f))
-      throw std::runtime_error("Edge search got unexpected IsNode result");
-    if(!p.vertex().ApproximatelyEqual(expected_point))
-      throw std::runtime_error("Found wrong point");
-    if(p.edges().front().dist != expected_distance)
-      throw std::runtime_error("Distance along the edge should always be 0 for node search");
-    const GraphTile* tile = reader.GetGraphTile(location.latlng_);
-    if(expected_name != tile->GetNames(tile->directededge(p.edges().front().id)->edgeinfo_offset())[0])
-      throw std::runtime_error("Didn't find expected road name");
+    throw std::runtime_error("Didn't find any node/edges");
+  if(p.IsNode() != (expected_distance == 0.f))
+    throw std::runtime_error("Edge search got unexpected IsNode result");
+  if(!p.vertex().ApproximatelyEqual(expected_point))
+    throw std::runtime_error("Found wrong point");
+  if(p.edges().front().dist != expected_distance)
+    throw std::runtime_error("Distance along the edge should always be 0 for node search");
+  const GraphTile* tile = reader.GetGraphTile(location.latlng_);
+  if(expected_name != tile->GetNames(tile->directededge(p.edges().front().id)->edgeinfo_offset())[0])
+    throw std::runtime_error("Didn't find expected road name");
 }
 
 void TestEdgeSearch() {

--- a/test/search.cc
+++ b/test/search.cc
@@ -142,7 +142,7 @@ void edge_search(valhalla::baldr::GraphReader& reader, const valhalla::baldr::Lo
   valhalla::baldr::PathLocation p = valhalla::loki::Search(location, reader, valhalla::loki::SearchStrategy::EDGE);
   if(!p.IsCorrelated())
     throw std::runtime_error("Didn't find any node/edges");
-  if(p.IsNode() != (expected_distance == 0.f))
+  if(p.IsNode() != (expected_distance == 0.f || expected_distance == 1.f))
     throw std::runtime_error("Edge search got unexpected IsNode result");
   if(!p.vertex().ApproximatelyEqual(expected_point))
     throw std::runtime_error("Found wrong point");
@@ -165,7 +165,6 @@ void edge_search(valhalla::baldr::GraphReader& reader, const valhalla::baldr::Lo
     if(found == found_names.end())
       throw std::runtime_error("Didn't find expected road name");
   }
-
 }
 
 void TestEdgeSearch() {
@@ -174,6 +173,8 @@ void TestEdgeSearch() {
 
   edge_search(reader, {{.105, .1}}, {.105, .1}, {"3"}, .5);
   edge_search(reader, {{.01, .1}}, {.01, .1}, {"1", "2", "3"}, 0);
+  edge_search(reader, {{.2, .1}}, {.2, .1}, {"0", "3", "4"}, 1);
+  //TODO: add more elaborate shape to test better the nodesnapping and distance along shape segment stuff
 }
 
 }

--- a/test/search.cc
+++ b/test/search.cc
@@ -187,7 +187,7 @@ void TestEdgeSearch() {
   auto conf = make_tile();
   valhalla::baldr::GraphReader reader(conf);
 
-  //edge_search(reader, {{.095, .1}}, {.095, .1}, "3", .5);
+  edge_search(reader, {{.095, .1}}, {.095, .1}, "3", .5);
 }
 
 }

--- a/test/search.cc
+++ b/test/search.cc
@@ -116,7 +116,7 @@ boost::property_tree::ptree make_tile() {
 
 void node_search(valhalla::baldr::GraphReader& reader, const valhalla::baldr::Location& location, const valhalla::midgard::PointLL& expected_point,
   const std::string& expected_name){
-  valhalla::baldr::PathLocation p = valhalla::loki::Search(location, reader, valhalla::loki::SearchStrategy::NODE);
+  valhalla::baldr::PathLocation p = valhalla::loki::Search(location, reader, valhalla::loki::PathThroughFilter, valhalla::loki::SearchStrategy::NODE);
   if(!p.IsCorrelated())
     throw std::runtime_error("Didn't find any node/edges");
   if(!p.IsNode())
@@ -139,7 +139,7 @@ void TestNodeSearch() {
 
 void edge_search(valhalla::baldr::GraphReader& reader, const valhalla::baldr::Location& location, const valhalla::midgard::PointLL& expected_point,
   const std::vector<std::string>& expected_names, const float expected_distance){
-  valhalla::baldr::PathLocation p = valhalla::loki::Search(location, reader, valhalla::loki::SearchStrategy::EDGE);
+  valhalla::baldr::PathLocation p = valhalla::loki::Search(location, reader, valhalla::loki::PathThroughFilter, valhalla::loki::SearchStrategy::EDGE);
   if(!p.IsCorrelated())
     throw std::runtime_error("Didn't find any node/edges");
   if(p.IsNode() != (expected_distance == 0.f || expected_distance == 1.f))

--- a/test/search.cc
+++ b/test/search.cc
@@ -11,7 +11,6 @@
 #include <valhalla/midgard/pointll.h>
 #include <valhalla/mjolnir/graphtilebuilder.h>
 #include <valhalla/baldr/tilehierarchy.h>
-#include <valhalla/baldr/exitsigninfo.h>
 #include <valhalla/mjolnir/nodeinfobuilder.h>
 #include <valhalla/mjolnir/directededgebuilder.h>
 

--- a/valhalla/loki/search.h
+++ b/valhalla/loki/search.h
@@ -20,10 +20,11 @@ namespace loki{
 enum class SearchStrategy : bool { NODE, EDGE };
 
 /**
- * A function point which returns true if an edge should be
- * filtered out of the correlated set
+ * A function pointer which returns true if an edge should be
+ * filtered out of the correlated set and false if the edge is usable
  */
 using EdgeFilter = bool (*)(const valhalla::baldr::DirectedEdge*);
+bool PassThroughFilter(const valhalla::baldr::DirectedEdge*) { return false; }
 
 /**
  * Find an location within the route network given an input location
@@ -36,7 +37,7 @@ using EdgeFilter = bool (*)(const valhalla::baldr::DirectedEdge*);
  * @return pathLocation  the correlated data with in the tile that matches the input
  */
 baldr::PathLocation Search(const baldr::Location& location, baldr::GraphReader& reader,
-  const SearchStrategy strategy = SearchStrategy::EDGE, EdgeFilter filter = nullptr);
+  const SearchStrategy strategy = SearchStrategy::EDGE, EdgeFilter filter = PassThroughFilter);
 
 }
 }

--- a/valhalla/loki/search.h
+++ b/valhalla/loki/search.h
@@ -6,6 +6,8 @@
 #include <valhalla/baldr/graphreader.h>
 #include <valhalla/baldr/directededge.h>
 
+#include <functional>
+
 namespace valhalla{
 namespace loki{
 
@@ -20,13 +22,11 @@ namespace loki{
 enum class SearchStrategy : bool { NODE, EDGE };
 
 /**
- * A function pointer which returns true if an edge should be
+ * A callable element which returns true if an edge should be
  * filtered out of the correlated set and false if the edge is usable
- * TODO: if ever we need to hold state when filtring we'll need to
- * update this to a functor and use something like std::function<>
- * in place of straight up function pointers
  */
-using EdgeFilter = bool (*)(const baldr::DirectedEdge*);
+using EdgeFilter = std::function<bool (const baldr::DirectedEdge*)>;
+const EdgeFilter PathThroughFilter = [](const baldr::DirectedEdge*){ return false; };
 
 /**
  * Find an location within the route network given an input location
@@ -34,12 +34,13 @@ using EdgeFilter = bool (*)(const baldr::DirectedEdge*);
  *
  * @param location  the position which needs to be correlated to the route network
  * @param reader    and object used to access tiled route data TODO: switch this out for a proper cache
- * @param strategy  what type of search to do
- * @param filter    a function to be used in the rejection of edges. defaults to a pass through filter
+ * @param filter    a function/functor to be used in the rejection of edges. defaults to a pass through filter
+ * @param strategy  what type of search to do, defaults to edge based searching
  * @return pathLocation  the correlated data with in the tile that matches the input
  */
 baldr::PathLocation Search(const baldr::Location& location, baldr::GraphReader& reader,
-  const SearchStrategy strategy = SearchStrategy::EDGE, EdgeFilter filter = [](const baldr::DirectedEdge*){ return false; });
+  EdgeFilter filter = PathThroughFilter,
+  const SearchStrategy strategy = SearchStrategy::EDGE);
 
 }
 }

--- a/valhalla/loki/search.h
+++ b/valhalla/loki/search.h
@@ -26,8 +26,7 @@ enum class SearchStrategy : bool { NODE, EDGE };
  * update this to a functor and use something like std::function<>
  * in place of straight up function pointers
  */
-using EdgeFilter = bool (*)(const valhalla::baldr::DirectedEdge*);
-bool PassThroughFilter(const valhalla::baldr::DirectedEdge*) { return false; }
+using EdgeFilter = bool (*)(const baldr::DirectedEdge*);
 
 /**
  * Find an location within the route network given an input location
@@ -36,11 +35,11 @@ bool PassThroughFilter(const valhalla::baldr::DirectedEdge*) { return false; }
  * @param location  the position which needs to be correlated to the route network
  * @param reader    and object used to access tiled route data TODO: switch this out for a proper cache
  * @param strategy  what type of search to do
- * @param filter    a function to be used in the rejection of edges
+ * @param filter    a function to be used in the rejection of edges. defaults to a pass through filter
  * @return pathLocation  the correlated data with in the tile that matches the input
  */
 baldr::PathLocation Search(const baldr::Location& location, baldr::GraphReader& reader,
-  const SearchStrategy strategy = SearchStrategy::EDGE, EdgeFilter filter = PassThroughFilter);
+  const SearchStrategy strategy = SearchStrategy::EDGE, EdgeFilter filter = [](const baldr::DirectedEdge*){ return false; });
 
 }
 }

--- a/valhalla/loki/search.h
+++ b/valhalla/loki/search.h
@@ -22,6 +22,9 @@ enum class SearchStrategy : bool { NODE, EDGE };
 /**
  * A function pointer which returns true if an edge should be
  * filtered out of the correlated set and false if the edge is usable
+ * TODO: if ever we need to hold state when filtring we'll need to
+ * update this to a functor and use something like std::function<>
+ * in place of straight up function pointers
  */
 using EdgeFilter = bool (*)(const valhalla::baldr::DirectedEdge*);
 bool PassThroughFilter(const valhalla::baldr::DirectedEdge*) { return false; }

--- a/valhalla/loki/search.h
+++ b/valhalla/loki/search.h
@@ -36,7 +36,7 @@ using EdgeFilter = bool (*)(const valhalla::baldr::DirectedEdge*);
  * @return pathLocation  the correlated data with in the tile that matches the input
  */
 baldr::PathLocation Search(const baldr::Location& location, baldr::GraphReader& reader,
-  const SearchStrategy strategy = SearchStrategy::NODE, EdgeFilter filter = nullptr);
+  const SearchStrategy strategy = SearchStrategy::EDGE, EdgeFilter filter = nullptr);
 
 }
 }


### PR DESCRIPTION
this pr adds the ability to search along edges and not just at the nodes and infact makes that the default. it also adds the ability (which we need to hook into using the costing methods from thor) to filter out edges that the costing wouldnt consider routable. currently nothing will be filtered out (which is the default mode). 

this is the brute force way to do the edge search. ill run a suite of routes using thor to get a gague on avg search time. then ill make another pr to fix a few todos and make it faster.