### PR TITLE
this adds the loki service layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ libtool
 
 # built objects
 loki_benchmark
+loki_service
 *.o
 .deps/
 .dirstamp

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,26 +38,29 @@ endif
 # lib valhalla compilation etc
 lib_LTLIBRARIES = libvalhalla_loki.la
 nobase_include_HEADERS = \
-	valhalla/loki/search.h 
+	valhalla/loki/search.h \
+	valhalla/loki/service.h
 libvalhalla_loki_la_SOURCES = \
-	src/loki/search.cc 
+	src/loki/search.cc \
+	src/loki/service.cc
 libvalhalla_loki_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-libvalhalla_loki_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@
+libvalhalla_loki_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB)
 
 #distributed executables
-bin_PROGRAMS = loki_benchmark
-loki_benchmark_SOURCES = \
-        src/loki/benchmark.cc
+bin_PROGRAMS = loki_benchmark loki_service
+loki_benchmark_SOURCES = src/loki/benchmark.cc
 loki_benchmark_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-loki_benchmark_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ @BOOST_SYSTEM_LIB@ libvalhalla_loki.la
-
+loki_benchmark_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB) libvalhalla_loki.la
+loki_service_SOURCES = src/loki/loki_service.cc
+loki_service_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
+loki_service_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB) libvalhalla_loki.la
 
 # tests
 check_PROGRAMS = \
 	test/search 
 test_search_SOURCES = test/search.cc test/test.cc
 test_search_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-test_search_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_loki.la
+test_search_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB) libvalhalla_loki.la
 
 TESTS = $(check_PROGRAMS)
 TEST_EXTENSIONS = .sh

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  environment:
+    LD_LIBRARY_PATH: .:`cat /etc/ld.so.conf.d/* | grep -v -E "#" | tr "\\n" ":" | sed -e "s/:$//g"`
   pre:
     - sudo add-apt-repository -y ppa:boost-latest/ppa
     #- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -14,16 +16,17 @@ checkout:
 dependencies:
   override:
     - sudo apt-get remove --purge -y libboost*
-    - sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev lcov protobuf-compiler libprotobuf-dev lua5.2 liblua5.2-dev
+    - sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev libboost-thread1.54-dev lcov protobuf-compiler libprotobuf-dev lua5.2 liblua5.2-dev
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+    - scripts/install_service_deps.sh
     #valhalla dependencies
     - cd deps; for dep in midgard baldr sif mjolnir; do cd $dep; ./autogen.sh && ./configure && sudo make -j4 install; cd ..; done
 
 test:
   pre:
-    - ./autogen.sh && ./configure --enable-coverage --with-valhalla-midgard=/usr/local --with-valhalla-baldr=/usr/local --with-valhalla-sif=/usr/local --with-valhalla-mjolnir=/usr/local
+    - ./autogen.sh && ./configure --enable-coverage --with-valhalla-midgard=/usr/local --with-valhalla-baldr=/usr/local --with-valhalla-sif=/usr/local --with-valhalla-mjolnir=/usr/local CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE
   override:
-    - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib make test -j4
+    - make test -j4
   post:
     - sudo make install
 

--- a/conf/valhalla.json
+++ b/conf/valhalla.json
@@ -28,20 +28,63 @@
     "logging": {
       "type": "std_out",
       "color": true
+    },
+    "service": {
+      "proxy": "ipc://loki"
     }
   },
   "thor": {
     "logging": {
       "type": "std_out",
       "color": true
+    },
+    "service": {
+      "proxy": "ipc://thor"
     }
   },
-  "tyr": {
-    "listen_address": "0.0.0.0",
-    "port": 8003,
+  "odin": {
     "logging": {
       "type": "std_out",
       "color": true
+    },
+    "service": {
+      "proxy": "ipc://odin"
+    }
+  },
+  "tyr": {
+    "logging": {
+      "type": "std_out",
+      "color": true
+    },
+    "service": {
+      "proxy": "ipc://tyr"
+    }
+  },
+  "httpd": {
+    "service": {
+      "listen": "tcp://*:8002",
+      "loopback": "ipc://loopback"
+    }
+  },
+  "costing_options": {
+    "auto": {
+      "maneuver_penalty": 5.0,
+      "gate_cost": 30.0,
+      "toll_booth_cost": 15.0,
+      "toll_booth_penalty": 0.0,
+      "country_crossing_cost": 600.0,
+      "country_crossing_penalty": 0.0
+    },
+    "auto_shorter": {
+    },
+    "pedestrian": {
+      "walking_speed": 5.1,
+      "walkway_factor": 0.9,
+      "alley_factor": 2.0,
+      "driveway_factor": 2.0,
+      "step_penalty": 30.0
+    },
+    "bicycle": {
     }
   }
 }

--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,11 @@ CHECK_VALHALLA_MJOLNIR
 AX_BOOST_BASE([1.54], , [AC_MSG_ERROR([cannot find Boost libraries, which are are required for building loki. Please install libboost-dev.])])
 AX_BOOST_PROGRAM_OPTIONS
 AX_BOOST_SYSTEM
+AX_BOOST_THREAD
 AX_BOOST_FILESYSTEM
+
+# check pkg-config dependencies
+PKG_CHECK_MODULES([DEPS], [libzmq >= 4.0 libprime_server >= 0.1.0])
 
 # optionally enable coverage information
 CHECK_COVERAGE

--- a/m4/ax_boost_thread.m4
+++ b/m4/ax_boost_thread.m4
@@ -1,0 +1,149 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_boost_thread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_THREAD
+#
+# DESCRIPTION
+#
+#   Test for Thread library from the Boost C++ libraries. The macro requires
+#   a preceding call to AX_BOOST_BASE. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_THREAD_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_THREAD
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Michael Tindal
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 27
+
+AC_DEFUN([AX_BOOST_THREAD],
+[
+	AC_ARG_WITH([boost-thread],
+	AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
+                   [use the Thread library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-thread=boost_thread-gcc-mt ]),
+        [
+        if test "$withval" = "no"; then
+			want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_thread_lib=""
+        else
+		    want_boost="yes"
+		ax_boost_user_thread_lib="$withval"
+		fi
+        ],
+        [want_boost="yes"]
+	)
+
+	if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+        AC_REQUIRE([AC_CANONICAL_BUILD])
+		CPPFLAGS_SAVED="$CPPFLAGS"
+		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+		export CPPFLAGS
+
+		LDFLAGS_SAVED="$LDFLAGS"
+		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+		export LDFLAGS
+
+        AC_CACHE_CHECK(whether the Boost::Thread library is available,
+					   ax_cv_boost_thread,
+        [AC_LANG_PUSH([C++])
+			 CXXFLAGS_SAVE=$CXXFLAGS
+
+			 if test "x$host_os" = "xsolaris" ; then
+				 CXXFLAGS="-pthreads $CXXFLAGS"
+			 elif test "x$host_os" = "xmingw32" ; then
+				 CXXFLAGS="-mthreads $CXXFLAGS"
+			 else
+				CXXFLAGS="-pthread $CXXFLAGS"
+			 fi
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/thread/thread.hpp>]],
+                                   [[boost::thread_group thrds;
+                                   return 0;]])],
+                   ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
+			 CXXFLAGS=$CXXFLAGS_SAVE
+             AC_LANG_POP([C++])
+		])
+		if test "x$ax_cv_boost_thread" = "xyes"; then
+           if test "x$host_os" = "xsolaris" ; then
+			  BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
+		   elif test "x$host_os" = "xmingw32" ; then
+			  BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
+		   else
+			  BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
+		   fi
+
+			AC_SUBST(BOOST_CPPFLAGS)
+
+			AC_DEFINE(HAVE_BOOST_THREAD,,[define if the Boost::Thread library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+
+			LDFLAGS_SAVE=$LDFLAGS
+                        case "x$host_os" in
+                          *bsd* )
+                               LDFLAGS="-pthread $LDFLAGS"
+                          break;
+                          ;;
+                        esac
+            if test "x$ax_boost_user_thread_lib" = "x"; then
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_thread* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'`; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                 [link_thread="no"])
+				done
+                if test "x$link_thread" != "xyes"; then
+                for libextension in `ls -r $BOOSTLIBDIR/boost_thread* 2>/dev/null | sed 's,.*/,,' | sed 's,\..*,,'`; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                 [link_thread="no"])
+				done
+                fi
+
+            else
+               for ax_lib in $ax_boost_user_thread_lib boost_thread-$ax_boost_user_thread_lib; do
+				      AC_CHECK_LIB($ax_lib, exit,
+                                   [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                   [link_thread="no"])
+                  done
+
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+			if test "x$link_thread" = "xno"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+                        else
+                           case "x$host_os" in
+                              *bsd* )
+				BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
+                              break;
+                              ;;
+                           esac
+
+			fi
+		fi
+
+		CPPFLAGS="$CPPFLAGS_SAVED"
+	LDFLAGS="$LDFLAGS_SAVED"
+	fi
+])

--- a/scripts/install_service_deps.sh
+++ b/scripts/install_service_deps.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# grab the latest zmq library:
+git clone --depth=1 --recurse-submodules --single-branch --branch=master https://github.com/zeromq/libzmq.git
+pushd libzmq
+./autogen.sh && ./configure --without-libsodium --without-documentation && make -j4
+sudo make install
+popd
+rm -rf libzmq
+
+# grab experimental zmq-based server API:
+git clone --depth=1 --recurse-submodules --single-branch --branch=master https://github.com/kevinkreiser/prime_server.git
+pushd prime_server
+./autogen.sh && ./configure && make test -j4
+sudo make install
+popd
+rm -rf prime_server

--- a/src/loki/loki_service.cc
+++ b/src/loki/loki_service.cc
@@ -1,0 +1,24 @@
+#include <iostream>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+#include "loki/service.h"
+
+int main(int argc, char** argv) {
+
+  if(argc < 2) {
+    std::cerr << "Usage: " << std::string(argv[0]) << " conf/valhalla.json" << std::endl;
+    return 1;
+  }
+
+  //config file
+  std::string config_file(argv[1]);
+  boost::property_tree::ptree config;
+  boost::property_tree::read_json(config_file, config);
+
+  //run the service worker
+  valhalla::loki::run_service(config);
+
+  return 0;
+}

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -190,7 +190,7 @@ namespace {
       //we require locations
       try {
         for(const auto& location : request.get_child("locations"))
-          locations.emplace_back(std::move(baldr::Location::FromPtree(location.second)));
+          locations.push_back(baldr::Location::FromPtree(location.second));
         if(locations.size() < 1)
           throw;
         //TODO: bail if this is too many
@@ -290,15 +290,15 @@ namespace valhalla {
   namespace loki {
     void run_service(const boost::property_tree::ptree& config) {
       //gets requests from the http server
-      auto upstream_endpoint = config.get<std::string>("loki.proxy");
+      auto upstream_endpoint = config.get<std::string>("loki.service.proxy") + "_out";
       //sends them on to thor
-      auto downstream_endpoint = config.get<std::string>("thor.proxy");
+      auto downstream_endpoint = config.get<std::string>("thor.service.proxy") + "_in";
       //or returns just location information back to the server
-      auto result_endpoint = config.get<std::string>("server.result_endpoint");
+      auto loopback_endpoint = config.get<std::string>("httpd.service.loopback");
 
       //listen for requests
       zmq::context_t context;
-      prime_server::worker_t worker(context, upstream_endpoint + "_downstream", downstream_endpoint + "_upstream", result_endpoint,
+      prime_server::worker_t worker(context, upstream_endpoint, downstream_endpoint, loopback_endpoint,
         std::bind(&loki_worker_t::work, loki_worker_t(config), std::placeholders::_1, std::placeholders::_2));
       worker.work();
 

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -1,0 +1,310 @@
+#include <functional>
+#include <string>
+#include <stdexcept>
+#include <vector>
+#include <unordered_map>
+#include <cstdint>
+#include <sstream>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/info_parser.hpp>
+
+#include <prime_server/prime_server.hpp>
+#include <prime_server/http_protocol.hpp>
+using namespace prime_server;
+
+#include <valhalla/midgard/logging.h>
+#include <valhalla/baldr/json.h>
+#include <valhalla/baldr/location.h>
+#include <valhalla/baldr/pathlocation.h>
+#include <valhalla/baldr/graphreader.h>
+#include <valhalla/sif/costfactory.h>
+#include <valhalla/sif/autocost.h>
+#include <valhalla/sif/bicyclecost.h>
+#include <valhalla/sif/pedestriancost.h>
+
+#include "loki/service.h"
+#include "loki/search.h"
+
+using namespace valhalla;
+using namespace valhalla::midgard;
+using namespace valhalla::baldr;
+using namespace valhalla::sif;
+
+
+namespace {
+  enum ACTION_TYPE {ROUTE, VIAROUTE, LOCATE, NEAREST};
+  const std::unordered_map<std::string, ACTION_TYPE> ACTION{
+    {"/route", ROUTE},
+    {"/viaroute", VIAROUTE},
+    {"/locate", LOCATE},
+    {"/nearest", NEAREST}
+  };
+
+  boost::property_tree::ptree from_request(const http_request_t& request) {
+    boost::property_tree::ptree pt;
+
+    //throw the json into the ptree
+    auto json = request.query.find("json");
+    if(json != request.query.end() && json->second.size()) {
+      std::istringstream is(json->second.front());
+      boost::property_tree::read_json(is, pt);
+    }
+
+    //throw the query params into the ptree
+    for(const auto& kv : request.query) {
+      //skip json or empty entries
+      if(kv.first == "json" || kv.second.size() == 0)
+        continue;
+
+      //turn single value entries into single key value
+      if(kv.second.size() == 1) {
+        pt.add(kv.first, kv.second.front());
+        continue;
+      }
+
+      //make an array of values for this key
+      boost::property_tree::ptree array;
+      for(const auto& value : kv.second) {
+        boost::property_tree::ptree element;
+        element.put("", value);
+        array.push_back(std::make_pair("", element));
+      }
+      pt.add_child(kv.first, array);
+    }
+
+    return pt;
+  }
+
+  //TODO: move json header to baldr
+  //TODO: make objects serialize themselves
+
+  json::ArrayPtr serialize_edges(const PathLocation& location, GraphReader& reader) {
+    auto array = json::array({});
+    std::unordered_multimap<uint64_t, PointLL> ids;
+    for(const auto& edge : location.edges()) {
+      try {
+        //get the osm way id
+        auto tile = reader.GetGraphTile(edge.id);
+        auto* directed_edge = tile->directededge(edge.id);
+        auto edge_info = tile->edgeinfo(directed_edge->edgeinfo_offset());
+        //check if we did this one before
+        auto range = ids.equal_range(edge_info->wayid());
+        bool duplicate = false;
+        for(auto id = range.first; id != range.second; ++id) {
+          if(id->second == location.vertex()) {
+            duplicate = true;
+            break;
+          }
+        }
+        //only serialize it if we didnt do it before
+        if(!duplicate) {
+          ids.emplace(edge_info->wayid(), location.vertex());
+          array->emplace_back(
+            json::map({
+              {"way_id", edge_info->wayid()},
+              {"correlated_lat", json::fp_t{location.latlng_.lat(), 6}},
+              {"correlated_lon", json::fp_t{location.latlng_.lng(), 6}}
+            })
+          );
+        }
+      }
+      catch(...) {
+        //this really shouldnt ever get hit
+        LOG_WARN("Expected edge no found in graph but found by loki::search!");
+      }
+    }
+    return array;
+  }
+
+  json::MapPtr serialize(const PathLocation& location, GraphReader& reader) {
+    return json::map({
+      {"ways", serialize_edges(location, reader)},
+      {"input_lat", json::fp_t{location.latlng_.lat(), 6}},
+      {"input_lon", json::fp_t{location.latlng_.lng(), 6}}
+    });
+  }
+
+  json::MapPtr serialize(const PointLL& ll, const std::string& reason) {
+    return json::map({
+      {"ways", static_cast<nullptr_t>(nullptr)},
+      {"input_lat", json::fp_t{ll.lat(), 6}},
+      {"input_lon", json::fp_t{ll.lng(), 6}},
+      {"reason", reason}
+    });
+  }
+
+  //TODO: throw this in the header to make it testable?
+  class loki_worker_t {
+   public:
+    loki_worker_t(const boost::property_tree::ptree& config):config(config), reader(config.get_child("mjolnir.hierarchy")) {
+      // Register edge/node costing methods
+      factory.Register("auto", sif::CreateAutoCost);
+      factory.Register("auto_shorter", sif::CreateAutoShorterCost);
+      factory.Register("bicycle", sif::CreateBicycleCost);
+      factory.Register("pedestrian", sif::CreatePedestrianCost);
+    }
+    worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info) {
+      //request should look like:
+      //  /[route|viaroute|locate|nearest]?loc=&json=&jsonp=
+
+      try{
+        //request parsing
+        auto request = http_request_t::from_string(static_cast<const char*>(job.front().data()), job.front().size());
+        auto action = ACTION.find(request.path);
+        if(action == ACTION.cend()) {
+          worker_t::result_t result{false};
+          http_response_t response(404, "Not Found", "Try any of: '/route' '/viaroute' '/locate' '/nearest'");
+          response.from_info(static_cast<http_request_t::info_t*>(request_info));
+          result.messages.emplace_back(response.to_string());
+          return result;
+        }
+
+        //parse the querys json
+        auto request_pt = from_request(request);
+        switch (action->second) {
+        case ROUTE:
+        case VIAROUTE:
+          init_request(request_pt);
+          return route(request_pt, static_cast<http_request_t::info_t*>(request_info));
+        case LOCATE:
+          init_request(request_pt);
+          return locate(request_pt, static_cast<http_request_t::info_t*>(request_info));
+        }
+
+        worker_t::result_t result{false};
+        http_response_t response(501, "Not Implemented");
+        response.from_info(static_cast<http_request_t::info_t*>(request_info));
+        result.messages.emplace_back(response.to_string());
+        return result;
+      }
+      catch(const std::exception& e) {
+        worker_t::result_t result{false};
+        http_response_t response(400, "Bad Request", e.what());
+        response.from_info(static_cast<http_request_t::info_t*>(request_info));
+        result.messages.emplace_back(response.to_string());
+        return result;
+      }
+    }
+    void init_request(const boost::property_tree::ptree& request) {
+      //we require locations
+      try {
+        for(const auto& location : request.get_child("locations"))
+          locations.emplace_back(std::move(baldr::Location::FromPtree(location.second)));
+        if(locations.size() < 1)
+          throw;
+        //TODO: bail if this is too many
+      }
+      catch(...) {
+        throw std::runtime_error("insufficiently specified required parameter 'locations'");
+      }
+
+      // Parse out the type of route - this provides the costing method to use
+      std::string costing;
+      try {
+        costing = request.get<std::string>("costing");
+      }
+      catch(...) {
+        throw std::runtime_error("No edge/node costing provided");
+      }
+
+      // Get the costing options. Get the base options from the config and the
+      // options for the specified costing method
+      std::string method_options = "costing_options." + costing;
+      boost::property_tree::ptree config_costing = config.get_child(method_options);
+      auto request_costing = request.get_child_optional(method_options);
+      if (request_costing) {
+        // If the request has any options for this costing type, merge the 2
+        // costing options - override any config options that are in the request.
+        // and add any request options not in the config.
+        for (auto r : *request_costing) {
+          config_costing.put_child(r.first, r.second);
+        }
+      }
+      cost = factory.Create(costing, config_costing);
+    }
+    worker_t::result_t route(boost::property_tree::ptree& request, const http_request_t::info_t* request_info) {
+      //currently we dont support multipoint, but we will
+      if(locations.size() != 2) {
+        worker_t::result_t result{false};
+        http_response_t response(501, "Not Implemented", "Only two locations supported at the moment");
+        response.from_info(request_info);
+        result.messages.emplace_back(response.to_string());
+        return result;
+      }
+
+      //correlate the various locations to the underlying graph
+      auto correlated = loki::Search(locations[0], reader, cost->GetFilter());
+      request.put_child("origin", correlated.ToPtree(0));
+      correlated = loki::Search(locations[1], reader, cost->GetFilter());
+      request.put_child("destination", correlated.ToPtree(1));
+      std::stringstream stream;
+      boost::property_tree::write_info(stream, request);
+
+      //ok send on the request with correlated origin and destination filled out
+      //using the boost ptree info format
+      //TODO: make a protobuf request object and pass that along, can be come
+      //part of thors path proto object and then get copied into odins trip object
+      worker_t::result_t result{true};
+      result.messages.emplace_back(stream.str());
+      return result;
+    }
+    worker_t::result_t locate(const boost::property_tree::ptree& request, const http_request_t::info_t* request_info) {
+      //correlate the various locations to the underlying graph
+      auto json = json::array({});
+      for(const auto& location : locations) {
+        try {
+          auto correlated = loki::Search(location, reader, cost->GetFilter());
+          json->emplace_back(serialize(correlated, reader));
+        }
+        catch(const std::exception& e) {
+          json->emplace_back(serialize(location.latlng_, e.what()));
+        }
+      }
+
+      //jsonp callback if need be
+      std::ostringstream stream;
+      auto jsonp = request.get_optional<std::string>("jsonp");
+      if(jsonp)
+        stream << *jsonp << '(';
+      stream << *json;
+      if(jsonp)
+        stream << ')';
+
+      worker_t::result_t result{false};
+      http_response_t response(200, "OK", stream.str(), headers_t{{"Content-type", "application/json;charset=utf-8"}});
+      response.from_info(request_info);
+      result.messages.emplace_back(response.to_string());
+      return result;
+    }
+   protected:
+    boost::property_tree::ptree config;
+    std::vector<Location> locations;
+    sif::CostFactory<sif::DynamicCost> factory;
+    valhalla::sif::cost_ptr_t cost;
+    valhalla::baldr::GraphReader reader;
+  };
+}
+
+namespace valhalla {
+  namespace loki {
+    void run_service(const boost::property_tree::ptree& config) {
+      //gets requests from the http server
+      auto upstream_endpoint = config.get<std::string>("loki.proxy");
+      //sends them on to thor
+      auto downstream_endpoint = config.get<std::string>("thor.proxy");
+      //or returns just location information back to the server
+      auto result_endpoint = config.get<std::string>("server.result_endpoint");
+
+      //listen for requests
+      zmq::context_t context;
+      prime_server::worker_t worker(context, upstream_endpoint + "_downstream", downstream_endpoint + "_upstream", result_endpoint,
+        std::bind(&loki_worker_t::work, loki_worker_t(config), std::placeholders::_1, std::placeholders::_2));
+      worker.work();
+
+      //TODO: should we listen for SIGINT and terminate gracefully/exit(0)?
+    }
+
+
+  }
+}

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -212,12 +212,12 @@ namespace {
       // options for the specified costing method
       std::string method_options = "costing_options." + costing;
       boost::property_tree::ptree config_costing = config.get_child(method_options);
-      auto request_costing = request.get_child_optional(method_options);
+      const auto& request_costing = request.get_child_optional(method_options);
       if (request_costing) {
         // If the request has any options for this costing type, merge the 2
         // costing options - override any config options that are in the request.
         // and add any request options not in the config.
-        for (auto r : *request_costing) {
+        for (const auto& r : *request_costing) {
           config_costing.put_child(r.first, r.second);
         }
       }

--- a/valhalla/loki/service.h
+++ b/valhalla/loki/service.h
@@ -1,0 +1,15 @@
+#ifndef __VALHALLA_LOKI_SERVICE_H__
+#define __VALHALLA_LOKI_SERVICE_H__
+
+#include <boost/property_tree/ptree.hpp>
+
+namespace valhalla {
+  namespace loki {
+
+    void run_service(const boost::property_tree::ptree& config);
+
+  }
+}
+
+
+#endif //__VALHALLA_LOKI_SERVICE_H__


### PR DESCRIPTION
two things are added here, a binary that makes use of the loki service layer code, and the loki service layer code with is part of the loki library. it makes use of all the prime_server zmq deps but its part of the library so the simple server in tyr can just use it. this way the same code will be run regardless of in production or testing on our local machines

the loki service is a bit complicated because its the front door. it has to know all of the possible requests the system can handle. it checks if you are asking for locate or route/viaroute (which reminds me it only looks for "locations" where viaroute expects "loc" so i suppose i should fix that..). anyway if locate, it resolves all the locations, and returns an http response right back to the client. if route or viaroute, it resolves the locations, but then adds on to the request the keys "origin" and "destination" with the resolved locations. it then uses ptree::write_info to serialize this to a string to pass on to thor.

in the future we should probably turn the request into some protobuf object, that be encapsulated within trip path and trip directions but for now this is fine and for the sizes of the requests likely wouldn't matter at all whether it were protobuf or not.