### PR TITLE
node snapping sends back all directed edges at that node. fixes #64

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -163,7 +163,6 @@ PathLocation CorrelateNode(GraphReader& reader, const NodeInfo* node, const Loca
 
     //do we want this edge
     if(!filter(edge)) {
-      std::cout << std::endl << "CONSIDERING: " << id.fields.id;
       PathLocation::PathEdge path_edge{std::move(id), 0.f, PathLocation::NONE};
       std::get<2>(closest_point) = edge->forward() ? 0 : info->shape().size() - 2;
       if(!HeadingFilter(edge, info, closest_point, location.heading_))
@@ -174,7 +173,6 @@ PathLocation CorrelateNode(GraphReader& reader, const NodeInfo* node, const Loca
 
     //do we want the evil twin
     if(!filter(other_edge)) {
-      std::cout << std::endl << "CONSIDERING: " << other_id.fields.id;
       PathLocation::PathEdge path_edge{std::move(other_id), 1.f, PathLocation::NONE};
       std::get<2>(closest_point) = other_edge->forward() ? 0 : info->shape().size() - 2;
       if(!HeadingFilter(other_edge, tile->edgeinfo(edge->edgeinfo_offset()), closest_point, location.heading_))

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -31,7 +31,7 @@ constexpr float HEADING_SAMPLE = 30.f;
 //cone width to use for cosine similarity comparisons for favoring heading
 constexpr float ANGLE_WIDTH = 88.f;
 
-//TODO: move to midgard and test the crap out of this
+//TODO: move this to midgard and test the crap out of it
 //we are essentially estimating the angle of the tangent
 //at a point along a discretised curve. we attempt to mostly
 //use the shape coming into the point on the curve but if there
@@ -92,7 +92,6 @@ bool HeadingFilter(const DirectedEdge* edge, const std::unique_ptr<const EdgeInf
 
   //get the angle of the shape from this point
   auto angle = Angle(std::get<2>(point), std::get<0>(point), info->shape(), edge->forward());
-  std::cout << " ANGLE " << angle;
   //we want the closest distance between two angles which can be had
   //across 0 or between the two so we just need to know which is bigger
   if(*heading > angle)


### PR DESCRIPTION
previously node snapping only send outbound edges. that didnt really make sense. when we edge snap we send back both directions, why wouldnt we do the same when we node snap. this allows us to remove: https://github.com/valhalla/thor/blob/master/src/thor/pathalgorithm.cc#L24 from `thor`

fixing the tests now