### PR TITLE
fixes #59. if closest point is graph node, return node snap result

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -144,7 +144,7 @@ bool FilterNode(const GraphTile* tile, const NodeInfo* node, const EdgeFilter fi
   return true;
 }
 
-PathLocation CorrelateNode(GraphReader& reader, const NodeInfo* node, const Location& location, const GraphTile* tile, EdgeFilter filter, const float sqdist){
+PathLocation CorrelateNode(GraphReader& reader, const Location& location, EdgeFilter filter, const GraphTile* tile, const NodeInfo* node, const float sqdist){
   PathLocation correlated(location);
   correlated.CorrelateVertex(node->latlng());
   std::list<PathLocation::PathEdge> heading_filtered;
@@ -195,25 +195,56 @@ PathLocation CorrelateNode(GraphReader& reader, const NodeInfo* node, const Loca
   return correlated;
 }
 
-const NodeInfo* FindClosestNode(const Location& location, const GraphTile* tile, EdgeFilter filter, float& sqdist){
-  //a place to keep track of which node is closest to our location
-  const NodeInfo* closest = nullptr;
-  sqdist = std::numeric_limits<float>::max();
-  DistanceApproximator approximator(location.latlng_);
-
-  //for each node
-  const auto start_node = tile->node(0);
-  const auto end_node = start_node + tile->header()->nodecount();
-  for(auto node = start_node; node < end_node; ++node) {
-    //if this is closer then its better, unless nothing interesting leaves it..
-    float node_sqdist = approximator.DistanceSquared(node->latlng());
-    if(node_sqdist < sqdist && !FilterNode(tile, node, filter)) {
-      sqdist = node_sqdist;
-      closest = node;
+PathLocation CorrelateEdge(GraphReader& reader, const Location& location, EdgeFilter filter, const std::tuple<PointLL, float, size_t>& closest_point,
+    const DirectedEdge* closest_edge, const GraphId& closest_edge_id, const std::unique_ptr<const EdgeInfo>&closest_edge_info) {
+  //now that we have an edge we can pass back all the info about it
+  PathLocation correlated(location);
+  if(closest_edge != nullptr){
+    //correlate the spot
+    correlated.CorrelateVertex(std::get<0>(closest_point));
+    //compute partial distance along the shape
+    double partial_length = 0;
+    for(size_t i = 0; i < std::get<2>(closest_point); ++i)
+        partial_length += closest_edge_info->shape()[i].Distance(closest_edge_info->shape()[i + 1]);
+    partial_length += closest_edge_info->shape()[std::get<2>(closest_point)].Distance(std::get<0>(closest_point));
+    float length_ratio = static_cast<float>(partial_length / static_cast<double>(closest_edge->length()));
+    // The length ratio at this point could be slightly greater than 1.0
+    // because of floating point imprecisions during the partial_length
+    // computation, so we clip it to 1.0.
+    length_ratio = std::min(1.0f, length_ratio);
+    if(!closest_edge->forward())
+      length_ratio = 1.f - length_ratio;
+    //side of street
+    auto side = GetSide(closest_edge, closest_edge_info, closest_point, location.latlng_);
+    //correlate the edge we found
+    std::list<PathLocation::PathEdge> heading_filtered;
+    if(HeadingFilter(closest_edge, closest_edge_info, closest_point, location.heading_))
+      heading_filtered.emplace_back(closest_edge_id, length_ratio, side);
+    else
+      correlated.CorrelateEdge(PathLocation::PathEdge{closest_edge_id, length_ratio, side});
+    //correlate its evil twin
+    const GraphTile* other_tile;
+    auto opposing_edge_id = reader.GetOpposingEdgeId(closest_edge_id, other_tile);
+    const auto* other_edge = other_tile->directededge(opposing_edge_id);
+    if(!filter(other_edge)) {
+      if(HeadingFilter(other_edge, closest_edge_info, closest_point, location.heading_))
+        heading_filtered.emplace_back(opposing_edge_id, 1 - length_ratio, FlipSide(side));
+      else
+        correlated.CorrelateEdge(PathLocation::PathEdge{opposing_edge_id, 1 - length_ratio, FlipSide(side)});
     }
+
+    //if we have nothing because of heading we'll just ignore it
+    if(correlated.edges().size() == 0 && heading_filtered.size())
+      for(auto& path_edge : heading_filtered)
+        correlated.CorrelateEdge(std::move(path_edge));
   }
 
-  return closest;
+  //if we found nothing that is no good..
+  if(correlated.edges().size() == 0)
+    throw std::runtime_error("No suitable edges near location");
+
+  //give it back
+  return correlated;
 }
 
 PathLocation NodeSearch(const Location& location, GraphReader& reader, EdgeFilter filter) {
@@ -226,14 +257,27 @@ PathLocation NodeSearch(const Location& location, GraphReader& reader, EdgeFilte
     throw std::runtime_error("No data found for location");
 
   //grab the absolute closest node to this location
-  float square_distance = 0.f;
-  const auto* node = FindClosestNode(location, tile, filter, square_distance);
+  float square_distance = std::numeric_limits<float>::max();
+  //a place to keep track of which node is closest to our location
+  const NodeInfo* closest = nullptr;
+  DistanceApproximator approximator(location.latlng_);
+  //for each node
+  const auto start_node = tile->node(0);
+  const auto end_node = start_node + tile->header()->nodecount();
+  for(auto node = start_node; node < end_node; ++node) {
+    //if this is closer then its better, unless nothing interesting leaves it..
+    float node_sqdist = approximator.DistanceSquared(node->latlng());
+    if(node_sqdist < square_distance && !FilterNode(tile, node, filter)) {
+      square_distance = node_sqdist;
+      closest = node;
+    }
+  }
   //TODO: look in other tiles
-  if(node == nullptr)
+  if(closest == nullptr)
     throw std::runtime_error("No data found for location");
 
   //get some information about it that we can use to make a path from it
-  return CorrelateNode(reader, node, location, tile, filter, square_distance);
+  return CorrelateNode(reader, location, filter, tile, closest, square_distance);
 }
 
 std::tuple<PointLL, float, size_t> Project(const PointLL& p, const std::vector<PointLL>& shape, const DistanceApproximator& approximator) {
@@ -307,10 +351,10 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, EdgeFilte
         //is it basically right on the start of the edge
         float sqdist;
         if((sqdist = approximator.DistanceSquared(start_node->latlng())) < sq_node_snap) {
-          return CorrelateNode(reader, start_node, location, tile, filter, sqdist);
+          return CorrelateNode(reader, location, filter, tile, start_node, sqdist);
         }//is it basically right on the end of the edge
         else if((sqdist = approximator.DistanceSquared(end_node->latlng())) < sq_node_snap) {
-          return CorrelateNode(reader, end_node, location, reader.GetGraphTile(edge->endnode()), filter, sqdist);
+          return CorrelateNode(reader, location, filter, reader.GetGraphTile(edge->endnode()), end_node, sqdist);
         }
 
         //we take the mid point of the edges end points and make a radius of half the length of the edge around it
@@ -327,6 +371,7 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, EdgeFilte
   }
 
   //TODO: if the tile is pretty sparse anyway just search the whole thing
+  //TODO: is this a good place to look at other neighbor tiles?
   //we only want to look at edges that are a decently close to our input, however if none
   //of them are close we just assume its a pretty empty tile and search the whole thing
   if(close.size() == 0)
@@ -351,54 +396,8 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, EdgeFilte
     }
   }
 
-  //now that we have an edge we can pass back all the info about it
-  PathLocation correlated(location);
-  if(closest_edge != nullptr){
-    //correlate the spot
-    correlated.CorrelateVertex(std::get<0>(closest_point));
-    //compute partial distance along the shape
-    double partial_length = 0;
-    for(size_t i = 0; i < std::get<2>(closest_point); ++i)
-        partial_length += closest_edge_info->shape()[i].Distance(closest_edge_info->shape()[i + 1]);
-    partial_length += closest_edge_info->shape()[std::get<2>(closest_point)].Distance(std::get<0>(closest_point));
-    float length_ratio = static_cast<float>(partial_length / static_cast<double>(closest_edge->length()));
-    // The length ratio at this point could be slightly greater than 1.0
-    // because of floating point imprecisions during the partial_length
-    // computation, so we clip it to 1.0.
-    length_ratio = std::min(1.0f, length_ratio);
-    if(!closest_edge->forward())
-      length_ratio = 1.f - length_ratio;
-    //side of street
-    auto side = GetSide(closest_edge, closest_edge_info, closest_point, location.latlng_);
-    //correlate the edge we found
-    std::list<PathLocation::PathEdge> heading_filtered;
-    if(HeadingFilter(closest_edge, closest_edge_info, closest_point, location.heading_))
-      heading_filtered.emplace_back(closest_edge_id, length_ratio, side);
-    else
-      correlated.CorrelateEdge(PathLocation::PathEdge{closest_edge_id, length_ratio, side});
-    //correlate its evil twin
-    const GraphTile* other_tile;
-    auto opposing_edge_id = reader.GetOpposingEdgeId(closest_edge_id, other_tile);
-    const auto* other_edge = other_tile->directededge(opposing_edge_id);
-    if(!filter(other_edge)) {
-      if(HeadingFilter(other_edge, closest_edge_info, closest_point, location.heading_))
-        heading_filtered.emplace_back(opposing_edge_id, 1 - length_ratio, FlipSide(side));
-      else
-        correlated.CorrelateEdge(PathLocation::PathEdge{opposing_edge_id, 1 - length_ratio, FlipSide(side)});
-    }
-
-    //if we have nothing because of heading we'll just ignore it
-    if(correlated.edges().size() == 0 && heading_filtered.size())
-      for(auto& path_edge : heading_filtered)
-        correlated.CorrelateEdge(std::move(path_edge));
-  }
-
-  //if we found nothing that is no good..
-  if(correlated.edges().size() == 0)
-    throw std::runtime_error("No suitable edges near location");
-
-  //give it back
-  return correlated;
+  //it was along the edge
+  return CorrelateEdge(reader, location, filter, closest_point, closest_edge, closest_edge_id, closest_edge_info);
 }
 
 }

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -396,6 +396,19 @@ PathLocation EdgeSearch(const Location& location, GraphReader& reader, EdgeFilte
     }
   }
 
+  //snap to node
+  bool front = std::get<0>(closest_point) == closest_edge_info->shape().front();
+  bool back = std::get<0>(closest_point) == closest_edge_info->shape().back();
+  //it was the begin node
+  if((front && closest_edge->forward()) || (back && !closest_edge->forward())) {
+    const GraphTile* other_tile;
+    auto opposing_edge = reader.GetOpposingEdge(closest_edge_id, other_tile);
+    return CorrelateNode(reader, location, filter, tile, other_tile->node(opposing_edge->endnode()), std::get<1>(closest_point));
+  }//it was the end node
+  else if((back && closest_edge->forward()) || (front && !closest_edge->forward())) {
+    const GraphTile* other_tile = reader.GetGraphTile(closest_edge->endnode());
+    return CorrelateNode(reader, location, filter, other_tile, other_tile->node(closest_edge->endnode()), std::get<1>(closest_point));
+  }
   //it was along the edge
   return CorrelateEdge(reader, location, filter, closest_point, closest_edge, closest_edge_id, closest_edge_info);
 }

--- a/test/search.cc
+++ b/test/search.cc
@@ -130,12 +130,14 @@ void make_tile() {
   tile.StoreTileData(h, tile_id);
 }
 
-void search(const valhalla::baldr::Location& location, const valhalla::midgard::PointLL& expected_point,
+void search(const valhalla::baldr::Location& location, bool expected_node, const valhalla::midgard::PointLL& expected_point,
   const std::vector<PathLocation::PathEdge>& expected_edges, const valhalla::loki::SearchStrategy& strategy){
 
   valhalla::baldr::GraphReader reader(conf);
   valhalla::baldr::PathLocation p = valhalla::loki::Search(location, reader, valhalla::loki::PassThroughFilter, strategy);
 
+  if(p.IsNode() != expected_node)
+    throw std::runtime_error(expected_node ? "Should've snapped to node" : "Shouldn't've snapped to node");
   if(!p.IsCorrelated())
     throw std::runtime_error("Didn't find any node/edges");
   if(!p.vertex().ApproximatelyEqual(expected_point))
@@ -156,30 +158,30 @@ void TestNodeSearch() {
   using S = PathLocation::SideOfStreet;
   using PE = PathLocation::PathEdge;
 
-  search({b.second}, b.second, { PE{{t, l, 0}, 0, S::NONE}, PE{{t, l, 1}, 0, S::NONE}, //leaving edges
+  search({b.second}, true, b.second, { PE{{t, l, 0}, 0, S::NONE}, PE{{t, l, 1}, 0, S::NONE}, //leaving edges
                                  PE{{t, l, 7}, 1, S::NONE}, PE{{t, l, 2}, 1, S::NONE} }, valhalla::loki::SearchStrategy::NODE); //arriving edges
 
-  search({a.second}, a.second, { PE{{t, l, 2}, 0, S::NONE}, PE{{t, l, 3}, 0, S::NONE}, PE{{t, l, 4}, 0, S::NONE}, //leaving edges
+  search({a.second}, true, a.second, { PE{{t, l, 2}, 0, S::NONE}, PE{{t, l, 3}, 0, S::NONE}, PE{{t, l, 4}, 0, S::NONE}, //leaving edges
                                  PE{{t, l, 1}, 1, S::NONE}, PE{{t, l, 8}, 1, S::NONE}, PE{{t, l, 5}, 1, S::NONE} }, valhalla::loki::SearchStrategy::NODE); //arriving edges
 
-  search({c.second}, c.second, { PE{{t, l, 5}, 0, S::NONE}, PE{{t, l, 6}, 0, S::NONE}, //leaving edges
+  search({c.second}, true, c.second, { PE{{t, l, 5}, 0, S::NONE}, PE{{t, l, 6}, 0, S::NONE}, //leaving edges
                                  PE{{t, l, 4}, 1, S::NONE}, PE{{t, l, 9}, 1, S::NONE} }, valhalla::loki::SearchStrategy::NODE); //arriving edges
 
-  search({d.second}, d.second, { PE{{t, l, 7}, 0, S::NONE}, PE{{t, l, 8}, 0, S::NONE}, PE{{t, l, 9}, 0, S::NONE}, //leaving edges
+  search({d.second}, true, d.second, { PE{{t, l, 7}, 0, S::NONE}, PE{{t, l, 8}, 0, S::NONE}, PE{{t, l, 9}, 0, S::NONE}, //leaving edges
                                  PE{{t, l, 0}, 1, S::NONE}, PE{{t, l, 3}, 1, S::NONE}, PE{{t, l, 6}, 1, S::NONE} }, valhalla::loki::SearchStrategy::NODE); //arriving edges
 
   //slightly off the node
-  search({d.second + PointLL(.0001, .0001)}, d.second, { PE{{t, l, 7}, 0, S::NONE}, PE{{t, l, 8}, 0, S::NONE}, PE{{t, l, 9}, 0, S::NONE}, //leaving edges
+  search({d.second + PointLL(.0001, .0001)}, true, d.second, { PE{{t, l, 7}, 0, S::NONE}, PE{{t, l, 8}, 0, S::NONE}, PE{{t, l, 9}, 0, S::NONE}, //leaving edges
                                                          PE{{t, l, 0}, 1, S::NONE}, PE{{t, l, 3}, 1, S::NONE}, PE{{t, l, 6}, 1, S::NONE} }, valhalla::loki::SearchStrategy::NODE); //arriving edges
 
   //with heading
   Location x{a.second};
   x.heading_ = 90;    //leaving only
-  search(x, a.second, { PE{{t, l, 3}, 0, S::NONE} }, valhalla::loki::SearchStrategy::NODE);
+  search(x, true, a.second, { PE{{t, l, 3}, 0, S::NONE} }, valhalla::loki::SearchStrategy::NODE);
   x.heading_ = 270;   //arriving only
-  search(x, a.second, { PE{{t, l, 8}, 1, S::NONE} }, valhalla::loki::SearchStrategy::NODE);
+  search(x, true, a.second, { PE{{t, l, 8}, 1, S::NONE} }, valhalla::loki::SearchStrategy::NODE);
   x.heading_ = 265;   //leaving                    //arriving
-  search(x, a.second, { PE{{t, l, 4}, 0, S::NONE}, PE{{t, l, 1}, 1, S::NONE}, PE{{t, l, 8}, 1, S::NONE} }, valhalla::loki::SearchStrategy::NODE);
+  search(x, true, a.second, { PE{{t, l, 4}, 0, S::NONE}, PE{{t, l, 1}, 1, S::NONE}, PE{{t, l, 8}, 1, S::NONE} }, valhalla::loki::SearchStrategy::NODE);
 }
 
 void TestEdgeSearch() {
@@ -189,40 +191,45 @@ void TestEdgeSearch() {
   using PE = PathLocation::PathEdge;
 
   //degenerate to node searches
-  search({a.second}, a.second, { PE{{t, l, 2}, 0, S::NONE}, PE{{t, l, 3}, 0, S::NONE}, PE{{t, l, 4}, 0, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
-  search({d.second}, d.second, { PE{{t, l, 7}, 0, S::NONE}, PE{{t, l, 8}, 0, S::NONE}, PE{{t, l, 9}, 0, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
+  search({a.second}, true, a.second, { PE{{t, l, 2}, 0, S::NONE}, PE{{t, l, 3}, 0, S::NONE}, PE{{t, l, 4}, 0, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
+  search({d.second}, true, d.second, { PE{{t, l, 7}, 0, S::NONE}, PE{{t, l, 8}, 0, S::NONE}, PE{{t, l, 9}, 0, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
+  //snap to end of edge degenerates to node searches
+  search({{d.second.first + .049, d.second.second}}, true, d.second,
+    { PE{{t, l, 7}, 0, S::NONE}, PE{{t, l, 8}, 0, S::NONE}, PE{{t, l, 9}, 0, S::NONE}, //leaving edges
+      PE{{t, l, 0}, 1, S::NONE}, PE{{t, l, 3}, 1, S::NONE}, PE{{t, l, 6}, 1, S::NONE}  //arriving edges
+    }, valhalla::loki::SearchStrategy::EDGE);
 
   //mid point search
-  search({a.second.MidPoint(d.second)}, a.second.MidPoint(d.second), { PE{{t, l, 3}, .5f, S::NONE}, PE{{t, l, 8}, .5f, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
+  search({a.second.MidPoint(d.second)}, false, a.second.MidPoint(d.second), { PE{{t, l, 3}, .5f, S::NONE}, PE{{t, l, 8}, .5f, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
 
   //set a point 40% along the edge runs with the shape direction
   PointLL answer = a.second.AffineCombination(.6f, .4f, d.second);
   auto ratio = a.second.Distance(answer) / a.second.Distance(d.second);
-  search({answer}, answer, { PE{{t, l, 3}, ratio, S::NONE}, PE{{t, l, 8}, 1.f - ratio, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
+  search({answer}, false, answer, { PE{{t, l, 3}, ratio, S::NONE}, PE{{t, l, 8}, 1.f - ratio, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
 
   //with heading
   Location x{answer};
   x.heading_ = 90;
-  search(x, answer, { PE{{t, l, 3}, ratio, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
+  search(x, false, answer, { PE{{t, l, 3}, ratio, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
   x.heading_ = 0;
-  search(x, answer, { PE{{t, l, 3}, ratio, S::NONE}, PE{{t, l, 8}, 1.f - ratio, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
+  search(x, false, answer, { PE{{t, l, 3}, ratio, S::NONE}, PE{{t, l, 8}, 1.f - ratio, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
   x.heading_ = 269;
-  search(x, answer, { PE{{t, l, 8}, 1.f - ratio, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
+  search(x, false, answer, { PE{{t, l, 8}, 1.f - ratio, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
 
   //check for side of street by offsetting the test point from the line orthogonally
   auto ortho = (d.second - a.second).GetPerpendicular(true).Normalize() * .01;
   PointLL test{answer.first + ortho.x(), answer.second + ortho.y()};
-  search({test}, answer, { PE{{t, l, 3}, ratio, S::RIGHT}, PE{{t, l, 8}, 1.f - ratio, S::LEFT} }, valhalla::loki::SearchStrategy::EDGE);
+  search({test}, false, answer, { PE{{t, l, 3}, ratio, S::RIGHT}, PE{{t, l, 8}, 1.f - ratio, S::LEFT} }, valhalla::loki::SearchStrategy::EDGE);
 
   //set a point 40% along the edge that runs in reverse of the shape
   answer = b.second.AffineCombination(.6f, .4f, d.second);
   ratio = b.second.Distance(answer) / b.second.Distance(d.second);
-  search({answer}, answer, { PE{{t, l, 0}, ratio, S::NONE}, PE{{t, l, 7}, 1.f - ratio, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
+  search({answer}, false, answer, { PE{{t, l, 0}, ratio, S::NONE}, PE{{t, l, 7}, 1.f - ratio, S::NONE} }, valhalla::loki::SearchStrategy::EDGE);
 
   //check for side of street by offsetting the test point from the line orthogonally
   ortho = (d.second - b.second).GetPerpendicular(false).Normalize() * .01;
   test.Set(answer.first + ortho.x(), answer.second + ortho.y());
-  search({test}, answer, { PE{{t, l, 0}, ratio, S::LEFT}, PE{{t, l, 7}, 1.f - ratio, S::RIGHT} }, valhalla::loki::SearchStrategy::EDGE);
+  search({test}, false, answer, { PE{{t, l, 0}, ratio, S::LEFT}, PE{{t, l, 7}, 1.f - ratio, S::RIGHT} }, valhalla::loki::SearchStrategy::EDGE);
 
   //TODO: add test that has to snap a point not actually on the geometry
 }


### PR DESCRIPTION
it can be the case that the closest point on an edge search is one of the end points of the edge. previously we still returned an edge result in that case. imagine the following:

                x
    ___________
         a     \
                \ b
                 \
                  \

previously we would have returned either both directed edges along `a` OR both directed edges along `b` (depending on the ordering in the tile). in truth we really want to consider all 4 directed edges at the node shared by `a` and `b`. this pr does that. it detects when you landed on an endpoint of an edge and returns a node result, which gives all edges leaving and arriving at the given node.

tested and confirmed

the diff is a bit of a :christmas_tree: due to some refactoring i did. really the only material change was this: https://github.com/valhalla/loki/commit/76a31adc036172a499e2188a1f8aad313a8eea48