### PR TITLE
Updated Max Route Locations for each Costing

### DIFF
--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -92,7 +92,7 @@ namespace valhalla {
     worker_t::result_t loki_worker_t::route(const ACTION_TYPE& action, boost::property_tree::ptree& request, http_request_t::info_t& request_info) {
       //see if any locations pairs are unreachable or too far apart
       auto lowest_level = reader.GetTileHierarchy().levels().rbegin();
-      auto max_distance = config.get<float>("service_limits.max_distance." + request.get<std::string>("costing"));
+      auto max_distance = config.get<float>("service_limits." + request.get<std::string>("costing") + ".max_distance");
       for(auto location = ++locations.cbegin(); location != locations.cend(); ++location) {
 
         //check connectivity

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -93,8 +93,7 @@ namespace {
 
 namespace valhalla {
   namespace loki {
-    loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config):config(config), reader(config.get_child("mjolnir.hierarchy")),
-      max_route_locations(config.get<size_t>("service_limits.max_route_locations")) {
+    loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config):config(config), reader(config.get_child("mjolnir.hierarchy")) {
 
       // Register edge/node costing methods
       factory.Register("auto", sif::CreateAutoCost);
@@ -162,6 +161,9 @@ namespace valhalla {
     void loki_worker_t::init_request(const ACTION_TYPE& action, const boost::property_tree::ptree& request) {
       //we require locations
       auto request_locations = request.get_child_optional("locations");
+      auto costing = request.get_optional<std::string>("costing");
+      auto max_route_locations = (costing ? config.get<size_t>("service_limits." + *costing + ".max_route_locations") : config.get<size_t>("service_limits.auto.max_route_locations"));
+
       if(!request_locations)
         throw std::runtime_error("Insufficiently specified required parameter '" + std::string(action == VIAROUTE ? "loc'" : "locations'"));
       for(const auto& location : *request_locations) {
@@ -179,7 +181,6 @@ namespace valhalla {
       LOG_INFO("location_count::" + std::to_string(request_locations->size()));
 
       //using the costing we can determine what type of edge filtering to use
-      auto costing = request.get_optional<std::string>("costing");
       if(!costing) {
         //locate doesnt require a filter
         if(action == LOCATE) {

--- a/test/service.cc
+++ b/test/service.cc
@@ -106,7 +106,7 @@ namespace {
         \"min_resample\": 10.0 \
       }, \
       \"costing_options\": { \"pedestrian\": {} } \
-        }";
+    }";
     boost::property_tree::json_parser::read_json(json, config);
 
     //service worker

--- a/test/service.cc
+++ b/test/service.cc
@@ -38,6 +38,12 @@ namespace {
     http_request_t(POST, "/route", "{\"locations\":[{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":-90}], \"costing\": \"pedestrian\"}"),
     http_request_t(GET, "/locate?json={\"locations\":[{\"lon\":0,\"lat\":90}], \"costing\": \"yak\"}"),
     http_request_t(POST, "/locate", "{\"locations\":[{\"lon\":0,\"lat\":90}], \"costing\": \"yak\"}"),
+    http_request_t(GET, "/route?json={\"locations\":[{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90}"
+      ",{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90}"
+      ",{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90}]}"),
+    http_request_t(POST, "/route", "{\"locations\":[{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90}"
+      ",{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90}"
+      ",{\"lon\":0,\"lat\":90},{\"lon\":0,\"lat\":90}]}")
   };
 
   const std::vector<std::pair<uint16_t,std::string> > responses {
@@ -59,12 +65,14 @@ namespace {
     {400, std::string("Insufficient number of locations provided")},
     {400, std::string("No edge/node costing provided")},
     {400, std::string("No edge/node costing provided")},
-    {400, std::string("Exceeded max route locations of 2")},
-    {400, std::string("Exceeded max route locations of 2")},
+    {400, std::string("No edge/node costing provided")},
+    {400, std::string("No edge/node costing provided")},
     {400, std::string("Locations are in unconnected regions. Go check/edit the map at osm.org")},
     {400, std::string("Locations are in unconnected regions. Go check/edit the map at osm.org")},
-    {400, std::string("No costing method found for 'yak'")},
-    {400, std::string("No costing method found for 'yak'")},
+    {400, std::string("No such node (service_limits.yak.max_route_locations)")},
+    {400, std::string("No such node (service_limits.yak.max_route_locations)")},
+    {400, std::string("Exceeded max route locations of 20")},
+    {400, std::string("Exceeded max route locations of 20")}
   };
 
 
@@ -92,8 +100,11 @@ namespace {
       \"thor\": { \"service\": { \"proxy\": \"ipc://test_thor_proxy\" } }, \
       \"httpd\": { \"service\": { \"loopback\": \"ipc://test_loki_results\" } }, \
       \"service_limits\": { \
-        \"max_distance\": { \"auto\": 5000000.0, \"auto_shorter\": 5000000.0, \"bus\": 5000000.0, \
-        \"pedestrian\": 250000.0, \"bicycle\": 500000.0, \"multimodal\": 500000.0 }, \"max_route_locations\": 2 }, \
+        \"auto\": { \"max_distance\": 5000000.0, \"max_route_locations\": 20 }, \
+        \"pedestrian\": { \"max_distance\": 250000.0, \"max_route_locations\": 50 }, \
+        \"max_shape\": 750000,\
+        \"min_resample\": 10.0 \
+      }, \
       \"costing_options\": { \"pedestrian\": {} } \
         }";
     boost::property_tree::json_parser::read_json(json, config);
@@ -126,7 +137,7 @@ namespace {
         if(response.code != responses[request - requests.cbegin() - 1].first)
           throw std::runtime_error("Unexpected response code");
         if(response.body != responses[request - requests.cbegin() - 1].second)
-          throw std::runtime_error("Unexpected response body");
+          throw std::runtime_error("Unexpected response body: " + response.body);
 
         return request != requests.cend();
       }, 1

--- a/valhalla/loki/service.h
+++ b/valhalla/loki/service.h
@@ -33,7 +33,6 @@ namespace valhalla {
       sif::CostFactory<sif::DynamicCost> factory;
       sif::EdgeFilter costing_filter;
       valhalla::baldr::GraphReader reader;
-      size_t max_route_locations;
     };
   }
 }


### PR DESCRIPTION
Updates to config for separate max route locations per costing; Updates to src and test to use new config changes.  This now sets bicycle, pedestrian and multimodal to 50 max locations and others are now 20.