### PR TITLE
fix seg fault

### DIFF
--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -102,6 +102,10 @@ namespace valhalla {
         max_locations.emplace(kv.first, config.get<size_t>("service_limits." + kv.first + ".max_locations"));
         max_distance.emplace(kv.first, config.get<float>("service_limits." + kv.first + ".max_distance"));
       }
+      for(const auto& matrix_type : std::list<std::string>{"one_to_many","many_to_one","many_to_many"}) {
+        max_locations.emplace(matrix_type, config.get<size_t>("service_limits." + matrix_type + ".max_locations"));
+        max_distance.emplace(matrix_type, config.get<float>("service_limits." + matrix_type + ".max_distance"));
+      }
       if (max_locations.empty())
         throw std::runtime_error("Missing max_locations configuration.");
       if (max_distance.empty())


### PR DESCRIPTION
Need to loop matrix types separately to add to max locations and max distance maps to fix seg fault.

 Also, I put a break point right after thor gets matrix response from backend and where I believe I'm getting weird distance:
Request:  
 http://valhalla.dev.mapzen.com/one_to_many?json={"locations"%3A[{"lat"%3A39.983841%2C"lon"%3A-76.735741%2C"street"%3A"US+30"}%2C{"lat"%3A39.937859%2C"lon"%3A-76.686249%2C"street"%3A"Springwood+Road"}]%2C"costing"%3A"auto"%2C"directions_options"%3A{"units"%3A"kilometers"}}&api_key=valhalla-t_16n1c

Breakpoint 1, (anonymous namespace)::serialize_one_to_many (correlated=std::vector of length 2, capacity 2 = {...}, 
    tds=std::vector of length 2, capacity 2 = {...}, units="km", distance_scale=0.001) at src/thor/service.cc:99
99	      {"one_to_many", json::array({serialize_row(correlated, tds, 0, 0, 0, tds.size(), distance_scale)})},
(gdb) p tds
$1 = std::vector of length 2, capacity 2 = {{time = 0, dist = 0}, {time = 564, dist = 4294967114}}
