### PR TITLE
Logging refactor

### DIFF
--- a/src/loki/locate_action.cc
+++ b/src/loki/locate_action.cc
@@ -135,20 +135,6 @@ namespace valhalla {
         }
       }
 
-      //get processing time for locate
-      auto time = std::chrono::high_resolution_clock::now();
-      auto msecs = std::chrono::duration_cast<std::chrono::milliseconds>(time.time_since_epoch()).count();
-      auto elapsed_time = static_cast<float>(msecs - request.get<size_t>("start_time"));
-
-      //log request if greater then X (ms)
-      if ((elapsed_time / locations.size()) > long_request) {
-        std::stringstream ss;
-        boost::property_tree::json_parser::write_json(ss, request, false);
-        LOG_WARN("locate request elapsed time (ms)::"+ std::to_string(elapsed_time));
-        LOG_WARN("locate request exceeded threshold::"+ ss.str());
-        midgard::logging::Log("long_locate_request", " [ANALYTICS] ");
-      }
-
       std::ostringstream stream;
       //jsonp callback if need be
       auto jsonp = request.get_optional<std::string>("jsonp");

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -138,11 +138,6 @@ namespace valhalla {
     }
 
     void loki_worker_t::init_request(const ACTION_TYPE& action, boost::property_tree::ptree& request) {
-      //get time for start of request
-      auto start_time = std::chrono::high_resolution_clock::now();
-      auto msecs = std::chrono::duration_cast<std::chrono::milliseconds>(start_time.time_since_epoch()).count();
-      request.put("start_time", msecs);
-
       //we require locations
       auto request_locations = request.get_child_optional("locations");
       if(!request_locations)
@@ -201,6 +196,9 @@ namespace valhalla {
     }
 
     worker_t::result_t loki_worker_t::work(const std::list<zmq::message_t>& job, void* request_info) {
+      //get time for start of request
+      auto start_time = std::chrono::high_resolution_clock::now();
+      auto start_msecs = std::chrono::duration_cast<std::chrono::milliseconds>(start_time.time_since_epoch()).count();
       auto& info = *static_cast<http_request_t::info_t*>(request_info);
       LOG_INFO("Got Loki Request " + std::to_string(info.id));
 
@@ -250,8 +248,8 @@ namespace valhalla {
 
         //get processing time for loki
         auto end_time = std::chrono::high_resolution_clock::now();
-        auto msecs = std::chrono::duration_cast<std::chrono::milliseconds>(end_time.time_since_epoch()).count();
-        auto elapsed_time = static_cast<float>(msecs - request_pt.get<size_t>("start_time"));
+        auto end_msecs = std::chrono::duration_cast<std::chrono::milliseconds>(end_time.time_since_epoch()).count();
+        auto elapsed_time = static_cast<float>(end_msecs - start_msecs);
         //log request if greater than X (ms)
         if ((elapsed_time / locations.size()) > long_request) {
           std::stringstream ss;

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -251,12 +251,11 @@ namespace valhalla {
         //get processing time for loki
         auto end_time = std::chrono::high_resolution_clock::now();
         auto msecs = std::chrono::duration_cast<std::chrono::milliseconds>(end_time.time_since_epoch()).count();
-        auto elapsed_time = static_cast<float>(msecs - request.get<size_t>("start_time"));
-
+        auto elapsed_time = static_cast<float>(msecs - request_pt.get<size_t>("start_time"));
         //log request if greater than X (ms)
         if ((elapsed_time / locations.size()) > long_request) {
           std::stringstream ss;
-          boost::property_tree::json_parser::write_json(ss, request, false);
+          boost::property_tree::json_parser::write_json(ss, request_pt, false);
           LOG_WARN("loki request elapsed time (ms)::"+ std::to_string(elapsed_time));
           LOG_WARN("loki request exceeded threshold::"+ ss.str());
           midgard::logging::Log("loki_long_request", " [ANALYTICS] ");
@@ -270,17 +269,6 @@ namespace valhalla {
         response.from_info(info);
         result.messages.emplace_back(response.to_string());
         valhalla::midgard::logging::Log("400::" + std::string(e.what()), " [ANALYTICS] ");
-
-        auto end_time = std::chrono::high_resolution_clock::now();
-        auto msecs = std::chrono::duration_cast<std::chrono::milliseconds>(end_time.time_since_epoch()).count();
-        auto elapsed_time = static_cast<float>(msecs - request.get<size_t>("start_time"));
-        if ((elapsed_time / locations.size()) > long_request) {
-          std::stringstream ss;
-          boost::property_tree::json_parser::write_json(ss, request, false);
-          LOG_WARN("loki request elapsed time (ms)::"+ std::to_string(elapsed_time));
-          LOG_WARN("loki request exceeded threshold::"+ ss.str());
-          midgard::logging::Log("loki_long_request", " [ANALYTICS] ");
-        }
         return result;
       }
     }


### PR DESCRIPTION
- removed logstash logging from locate_action.cc
- moved init_request to come before the work method
- added "loki" specific start time to request object
- added elapsed time logic at end of work method
- renamed logstash long request logging to be more consistent