### PR TITLE
added range check for MM walking distances.

### DIFF
--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -17,10 +17,6 @@ namespace {
   const headers_t::value_type JSON_MIME{"Content-type", "application/json;charset=utf-8"};
   const headers_t::value_type JS_MIME{"Content-type", "application/javascript;charset=utf-8"};
 
-  // Minimum and maximum walking distances (to validate input).
-  constexpr uint32_t kMinWalkingDistance = 1; // 1 meter
-  constexpr uint32_t kMaxWalkingDistance = 10000; // 10 km
-
   void check_locations(const size_t location_count, const size_t max_locations) {
     //check that location size does not exceed max.
     if (location_count > max_locations)
@@ -60,21 +56,23 @@ namespace valhalla {
       // Validate walking distances (make sure they are in the accepted range)
       if (costing == "multimodal" || costing == "transit") {
 
-        auto max_distance = request.get_optional<int>("costing_options.pedestrian.max_distance_mm");
-        auto max_transfer_distance = request.get_optional<int>("costing_options.pedestrian.max_transfer_distance_mm");
+        auto transit_start_end_max_distance =
+            request.get_optional<int>("costing_options.pedestrian.transit_start_end_max_distance");
+        auto transit_transfer_max_distance =
+            request.get_optional<int>("costing_options.pedestrian.transit_transfer_max_distance");
 
-        if (max_distance) {
-          if (*max_distance < kMinWalkingDistance || *max_distance > kMaxWalkingDistance) {
+        if (transit_start_end_max_distance) {
+          if (*transit_start_end_max_distance < min_transit_walking_dis || *transit_start_end_max_distance > max_transit_walking_dis) {
             throw std::runtime_error("Outside the valid walking distance at the beginning or end of a multimodal route.  Min: " +
-                                     std::to_string(kMinWalkingDistance) + " Max: " + std::to_string(kMaxWalkingDistance) +
-                                     " (Meters) ");
+                                     std::to_string(min_transit_walking_dis) + " Max: " + std::to_string(max_transit_walking_dis) +
+                                     " (Meters)");
           }
         }
-        if (max_transfer_distance) {
-          if (*max_transfer_distance < kMinWalkingDistance || *max_transfer_distance > kMaxWalkingDistance) {
+        if (transit_transfer_max_distance) {
+          if (*transit_transfer_max_distance < min_transit_walking_dis || *transit_transfer_max_distance > max_transit_walking_dis) {
             throw std::runtime_error("Outside the valid walking distance between stops of a multimodal route.  Min: " +
-                                     std::to_string(kMinWalkingDistance) + " Max: " + std::to_string(kMaxWalkingDistance) +
-                                     " (Meters) ");
+                                     std::to_string(min_transit_walking_dis) + " Max: " + std::to_string(max_transit_walking_dis) +
+                                     " (Meters)");
           }
         }
       }

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -127,9 +127,9 @@ namespace valhalla {
         throw std::runtime_error("Missing max_distance configuration.");
 
       min_transit_walking_dis =
-          config.get<int>("costing_options.pedestrian.min_transit_walking_distance");
+          config.get<int>("service_limits.pedestrian.min_transit_walking_distance");
       max_transit_walking_dis =
-          config.get<int>("costing_options.pedestrian.max_transit_walking_distance");
+          config.get<int>("service_limits.pedestrian.max_transit_walking_distance");
 
       // Register edge/node costing methods
       // TODO: move this into the loop above

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -126,6 +126,11 @@ namespace valhalla {
       if (max_distance.empty())
         throw std::runtime_error("Missing max_distance configuration.");
 
+      min_transit_walking_dis =
+          config.get<int>("costing_options.pedestrian.min_transit_walking_distance");
+      max_transit_walking_dis =
+          config.get<int>("costing_options.pedestrian.max_transit_walking_distance");
+
       // Register edge/node costing methods
       // TODO: move this into the loop above
       factory.Register("auto", sif::CreateAutoCost);

--- a/test/service.cc
+++ b/test/service.cc
@@ -100,7 +100,8 @@ namespace {
       \"httpd\": { \"service\": { \"loopback\": \"ipc:///tmp/test_loki_results\" } }, \
       \"service_limits\": { \
         \"auto\": { \"max_distance\": 5000000.0, \"max_locations\": 20 }, \
-        \"pedestrian\": { \"max_distance\": 250000.0, \"max_locations\": 50 }, \
+        \"pedestrian\": { \"max_distance\": 250000.0, \"max_locations\": 50, \
+        \"min_transit_walking_distance\": 1, \"max_transit_walking_distance\": 10000 }, \
         \"one_to_many\": { \"max_distance\": 200000.0, \"max_locations\": 50 }, \
         \"many_to_one\": { \"max_distance\": 200000.0, \"max_locations\": 50 }, \
         \"many_to_many\": { \"max_distance\": 200000.0, \"max_locations\": 50}, \

--- a/valhalla/loki/service.h
+++ b/valhalla/loki/service.h
@@ -38,6 +38,9 @@ namespace valhalla {
       std::unordered_map<std::string, size_t> max_locations;
       std::unordered_map<std::string, float> max_distance;
       float long_request;
+      // Minimum and maximum walking distances (to validate input).
+      uint32_t min_transit_walking_dis;
+      uint32_t max_transit_walking_dis;
     };
   }
 }


### PR DESCRIPTION
Errors returned.

Outside the valid walking distance at the beginning or end of a multimodal route.  Min: 1 Max: 10000 (Meters) 
Outside the valid walking distance between stops of a multimodal route.  Min: 1 Max: 10000 (Meters) 

Sample request:
http://localhost:8002/route?json={"locations":[{"lat":40.749706,"lon":-73.991562,"type":"break","street":"Penn Plaza"},{"lat":40.73093,"lon":-73.991379,"type":"break","street":"Wanamaker Place"}],"costing":"multimodal","costing_options":{"transit":{"use_bus":"1.0","use_rail":"0.0","use_transfers":"0.3"},"pedestrian":**{"max_distance_mm":"0"}**}}&api_key=valhalla-xxxxxxx