### PR TITLE
add node filter to search api

### DIFF
--- a/src/loki/locate_action.cc
+++ b/src/loki/locate_action.cc
@@ -127,7 +127,7 @@ namespace valhalla {
 
       for(const auto& location : locations) {
         try {
-          auto correlated = loki::Search(location, reader, costing_filter);
+          auto correlated = loki::Search(location, reader, edge_filter, node_filter);
           json->emplace_back(serialize(request.get_optional<std::string>("id"), correlated, reader, verbose));
         }
         catch(const std::exception& e) {

--- a/src/loki/matrix_action.cc
+++ b/src/loki/matrix_action.cc
@@ -104,7 +104,7 @@ namespace valhalla {
       }
       //correlate the various locations to the underlying graph
       for(size_t i = 0; i < locations.size(); ++i) {
-        auto correlated = loki::Search(locations[i], reader, costing_filter);
+        auto correlated = loki::Search(locations[i], reader, edge_filter, node_filter);
         request.put_child("correlated_" + std::to_string(i), correlated.ToPtree(i));
       }
 

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -120,7 +120,7 @@ namespace valhalla {
 
       //correlate the various locations to the underlying graph
       for(size_t i = 0; i < locations.size(); ++i) {
-        auto correlated = loki::Search(locations[i], reader, costing_filter);
+        auto correlated = loki::Search(locations[i], reader, edge_filter, node_filter);
         request.put_child("correlated_" + std::to_string(i), correlated.ToPtree(i));
       }
 

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -436,6 +436,7 @@ namespace valhalla {
 namespace loki {
 
 PathLocation Search(const Location& location, GraphReader& reader, const EdgeFilter& edge_filter, const NodeFilter& node_filter) {
+  //TODO: check if its an island and then search again
   return search(location, reader, edge_filter);
 }
 

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -278,7 +278,7 @@ std::tuple<PointLL, float, size_t> project(const PointLL& p, const std::vector<P
 // larger routing graph. Does a breadth first search - if possible paths are
 // exhausted within some threshold this returns a set of edges within the
 // island.
-std::unordered_set<GraphId> IsDisconnected(const PathLocation& location,
+std::unordered_set<GraphId> island(const PathLocation& location,
              GraphReader& reader, const NodeFilter& node_filter,
              const EdgeFilter& edge_filter, const uint32_t edge_threshold,
              const uint32_t length_threshold, const uint32_t node_threshold) {
@@ -340,12 +340,7 @@ std::unordered_set<GraphId> IsDisconnected(const PathLocation& location,
   return (todo.size() == 0) ? done : std::unordered_set<GraphId>{};
 }
 
-}
-
-namespace valhalla {
-namespace loki {
-
-PathLocation Search(const Location& location, GraphReader& reader, const EdgeFilter& filter) {
+PathLocation search(const Location& location, GraphReader& reader, const EdgeFilter& edge_filter) {
   //iterate over bins in a closest first manner
   const auto& tiles = reader.GetTileHierarchy().levels().rbegin()->second.tiles;
   const auto level = reader.GetTileHierarchy().levels().rbegin()->first;
@@ -388,8 +383,8 @@ PathLocation Search(const Location& location, GraphReader& reader, const EdgeFil
           tile = reader.GetGraphTile(e);
         const auto* edge = tile->directededge(e);
         //no thanks on this one or it evil twin
-        if(filter(edge) && (!(e = reader.GetOpposingEdgeId(e, tile)).Is_Valid() ||
-          filter(edge = tile->directededge(e)))) {
+        if(edge_filter(edge) && (!(e = reader.GetOpposingEdgeId(e, tile)).Is_Valid() ||
+          edge_filter(edge = tile->directededge(e)))) {
           continue;
         }
         //get some info about the edge
@@ -424,15 +419,24 @@ PathLocation Search(const Location& location, GraphReader& reader, const EdgeFil
   if((front && closest_edge->forward()) || (back && !closest_edge->forward())) {
     const GraphTile* other_tile;
     auto opposing_edge = reader.GetOpposingEdge(closest_edge_id, other_tile);
-    return correlate_node(reader, location, filter, closest_tile, closest_tile->node(opposing_edge->endnode()), std::get<1>(closest_point));
+    return correlate_node(reader, location, edge_filter, closest_tile, closest_tile->node(opposing_edge->endnode()), std::get<1>(closest_point));
   }
   //it was the end node
   if((back && closest_edge->forward()) || (front && !closest_edge->forward())) {
     const GraphTile* other_tile = reader.GetGraphTile(closest_edge->endnode());
-    return correlate_node(reader, location, filter, other_tile, other_tile->node(closest_edge->endnode()), std::get<1>(closest_point));
+    return correlate_node(reader, location, edge_filter, other_tile, other_tile->node(closest_edge->endnode()), std::get<1>(closest_point));
   }
   //it was along the edge
-  return correlate_edge(reader, location, filter, closest_point, closest_edge, closest_edge_id, closest_edge_info);
+  return correlate_edge(reader, location, edge_filter, closest_point, closest_edge, closest_edge_id, closest_edge_info);
+}
+
+}
+
+namespace valhalla {
+namespace loki {
+
+PathLocation Search(const Location& location, GraphReader& reader, const EdgeFilter& edge_filter, const NodeFilter& node_filter) {
+  return search(location, reader, edge_filter);
 }
 
 }

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -245,7 +245,8 @@ namespace valhalla {
       if(!costing) {
         //locate doesnt require a filter
         if(action == LOCATE) {
-          costing_filter = loki::PassThroughFilter;
+          edge_filter = loki::PassThroughEdgeFilter;
+          node_filter = loki::PassThroughNodeFilter;
           return;
         }//but everything else does
         else
@@ -271,10 +272,15 @@ namespace valhalla {
         boost::property_tree::ptree overridden = *config_costing;
         for(const auto& r : *request_costing)
           overridden.put_child(r.first, r.second);
-        costing_filter = factory.Create(*costing, overridden)->GetFilter();
+        auto c = factory.Create(*costing, overridden);
+        edge_filter = c->GetFilter();
+        node_filter = c->GetNodeFilter();
       }// No options to override so use the config options verbatim
-      else
-        costing_filter = factory.Create(*costing, *config_costing)->GetFilter();
+      else {
+        auto c = factory.Create(*costing, *config_costing);
+        edge_filter = c->GetFilter();
+        node_filter = c->GetNodeFilter();
+      }
     }
 
     void loki_worker_t::cleanup() {

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -273,12 +273,12 @@ namespace valhalla {
         for(const auto& r : *request_costing)
           overridden.put_child(r.first, r.second);
         auto c = factory.Create(*costing, overridden);
-        edge_filter = c->GetFilter();
+        edge_filter = c->GetEdgeFilter();
         node_filter = c->GetNodeFilter();
       }// No options to override so use the config options verbatim
       else {
         auto c = factory.Create(*costing, *config_costing);
-        edge_filter = c->GetFilter();
+        edge_filter = c->GetEdgeFilter();
         node_filter = c->GetNodeFilter();
       }
     }

--- a/test/search.cc
+++ b/test/search.cc
@@ -151,7 +151,8 @@ void search(const valhalla::baldr::Location& location, bool expected_node, const
   boost::property_tree::json_parser::read_json(json, conf);
 
   valhalla::baldr::GraphReader reader(conf);
-  valhalla::baldr::PathLocation p = valhalla::loki::Search(location, reader, valhalla::loki::PassThroughFilter);
+  valhalla::baldr::PathLocation p = valhalla::loki::Search(location, reader,
+    valhalla::loki::PassThroughEdgeFilter, valhalla::loki::PassThroughNodeFilter);
 
   if(p.IsNode() != expected_node)
     throw std::runtime_error(expected_node ? "Should've snapped to node" : "Shouldn't've snapped to node");

--- a/valhalla/loki/search.h
+++ b/valhalla/loki/search.h
@@ -19,18 +19,26 @@ namespace loki{
  * TODO: remove the filtering of transit edges when they get proper
  * opposing edges added to the graph
  */
-const sif::EdgeFilter PassThroughFilter = [](const baldr::DirectedEdge* edge){ return edge->trans_up() || edge->trans_down() || edge->IsTransitLine(); };
+const sif::EdgeFilter PassThroughEdgeFilter = [](const baldr::DirectedEdge* edge){ return edge->trans_up() || edge->trans_down() || edge->IsTransitLine(); };
+
+/**
+ * A callable element which returns true if a node should be
+ * filtered out of a graph traversal
+ */
+const sif::NodeFilter PassThroughNodeFilter = [](const baldr::NodeInfo* node){ return false; };
 
 /**
  * Find an location within the route network given an input location
  * same tiled route data and a search strategy
  *
- * @param location  the position which needs to be correlated to the route network
- * @param reader    and object used to access tiled route data TODO: switch this out for a proper cache
- * @param filter    a function/functor to be used in the rejection of edges. defaults to a pass through filter
+ * @param location       the position which needs to be correlated to the route network
+ * @param reader         and object used to access tiled route data TODO: switch this out for a proper cache
+ * @param edge_filter    a function/functor to be used in the rejection of edges. defaults to a pass through filter
+ * @param node_filter    a function/functor to be used in the rejection of nodes used in graph traversal. defaults to a pass through filter
  * @return pathLocation  the correlated data with in the tile that matches the input
  */
-baldr::PathLocation Search(const baldr::Location& location, baldr::GraphReader& reader, const sif::EdgeFilter& filter = PassThroughFilter);
+baldr::PathLocation Search(const baldr::Location& location, baldr::GraphReader& reader,
+  const sif::EdgeFilter& edge_filter = PassThroughEdgeFilter, const sif::NodeFilter& node_filter = PassThroughNodeFilter);
 
 }
 }

--- a/valhalla/loki/service.h
+++ b/valhalla/loki/service.h
@@ -33,7 +33,8 @@ namespace valhalla {
       boost::property_tree::ptree config;
       std::vector<baldr::Location> locations;
       sif::CostFactory<sif::DynamicCost> factory;
-      sif::EdgeFilter costing_filter;
+      sif::EdgeFilter edge_filter;
+      sif::NodeFilter node_filter;
       valhalla::baldr::GraphReader reader;
       std::string action_str;
       std::unordered_map<std::string, size_t> max_locations;


### PR DESCRIPTION
this is the first in a series of small prs to add 2 bits of functionality.

the first bit will be better edge finding:

- if we find an edge in an island we try to find more edges not in islands
- if the request supplied a name we'll try to match it

the second bit will bit a new method in the api that will return contiguous sections of the graph for use in interpolated geocoding

i'm going to try to as much as i can make lots of small prs instead of larger ones al at once