### PR TITLE
Scale longitude in the project method.

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -236,32 +236,35 @@ std::tuple<PointLL, float, size_t> project(const PointLL& p, const std::vector<P
   PointLL closest_point{};
   DistanceApproximator approx(p);
 
+  // Longitude (x) is scaled by the cos of the latitude so that distances are
+  // correct in lat,lon space
+  float lon_scale = cosf(p.lat() * kRadPerDeg);
+
   //for each segment
+  PointLL point;
   for(size_t i = 0; i < shape.size() - 1; ++i) {
     //project a onto b where b is the origin vector representing this segment
     //and a is the origin vector to the point we are projecting, (a.b/b.b)*b
     const auto& u = shape[i];
     const auto& v = shape[i + 1];
     auto bx = v.first - u.first;
+    auto bx2 = bx * lon_scale;
     auto by = v.second - u.second;
-    auto sq = bx*bx + by*by;
+    auto sq = bx2*bx2 + by*by;
     //avoid divided-by-zero which gives a NaN scale, otherwise comparisons below will fail
-    const auto scale = sq > 0? (((p.first - u.first)*bx + (p.second - u.second)*by) / sq) : 0.f;
+    auto scale = sq > 0? (((p.first - u.first)*bx2*lon_scale + (p.second - u.second)*by) / sq) : 0.f;
+
     //projects along the ray before u
     if(scale <= 0.f) {
-      bx = u.first;
-      by = u.second;
+      point = { u.first, u.second };
     }//projects along the ray after v
     else if(scale >= 1.f) {
-      bx = v.first;
-      by = v.second;
+      point = { v.first, v.second };
     }//projects along the ray between u and v
     else {
-      bx = bx*scale + u.first;
-      by = by*scale + u.second;
+      point = { u.first+bx*scale, u.second+by*scale };
     }
     //check if this point is better
-    PointLL point(bx, by);
     const auto sq_distance = approx.DistanceSquared(point);
     if(sq_distance < sq_closest_distance) {
       closest_segment = i;
@@ -269,7 +272,6 @@ std::tuple<PointLL, float, size_t> project(const PointLL& p, const std::vector<P
       closest_point = std::move(point);
     }
   }
-
   return std::make_tuple(std::move(closest_point), sqrt(sq_closest_distance), closest_segment);
 }
 

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -248,11 +248,13 @@ std::tuple<PointLL, float, size_t> project(const PointLL& p, const std::vector<P
     const auto& u = shape[i];
     const auto& v = shape[i + 1];
     auto bx = v.first - u.first;
-    auto bx2 = bx * lon_scale;
     auto by = v.second - u.second;
+
+    // Scale longitude when finding the projection. Avoid divided-by-zero
+    // which gives a NaN scale, otherwise comparisons below will fail
+    auto bx2 = bx * lon_scale;
     auto sq = bx2*bx2 + by*by;
-    //avoid divided-by-zero which gives a NaN scale, otherwise comparisons below will fail
-    auto scale = sq > 0? (((p.first - u.first)*bx2*lon_scale + (p.second - u.second)*by) / sq) : 0.f;
+    auto scale = sq > 0 ?  (((p.first - u.first)*lon_scale*bx2 + (p.second - u.second)*by) / sq) : 0.f;
 
     //projects along the ray before u
     if(scale <= 0.f) {


### PR DESCRIPTION
Fixes #123 
Need to scale longitude differences by the cos of the latitude so that distances are approximately equal between latitude and longitude. 